### PR TITLE
Find nmatrix.h from require_paths

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -4,9 +4,9 @@ require 'rdoc/task'
 
 RB_GSL_VERSION = File.readlines('VERSION')[0].chomp
 
-spec = gemspec = eval(IO.read("gsl.gemspec"))
+spec = gemspec = eval(IO.read("gsl-nmatrix.gemspec"))
 
-Rake::PackageTask.new('rb-gsl', RB_GSL_VERSION) do |pkg|
+Rake::PackageTask.new('gsl-nmatrix', RB_GSL_VERSION) do |pkg|
   pkg.need_zip = true
   pkg.need_tar = true
   pkg.package_files = spec.files

--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -266,8 +266,15 @@ begin
   require 'rubygems'
   nm_gemspec=Gem::Specification.find_by_path('nmatrix.h')
   if nm_gemspec
-    nmatrix_config = File.join(nm_gemspec.full_gem_path, nm_gemspec.require_path)
-    $CPPFLAGS = " -I#{nmatrix_config} "+$CPPFLAGS
+    require 'pathname'
+    paths = nm_gemspec.require_paths.map do |path|
+      if Pathname.new(path).relative?
+        File.join(nm_gemspec.full_gem_path, path)
+      else
+        path
+      end
+    end
+    find_header('nmatrix.h', *paths)
   end
 rescue LoadError
 end

--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -248,8 +248,15 @@ begin
   require 'rubygems'
   na_gemspec=Gem::Specification.find_by_path('narray.h')
   if na_gemspec
-    narray_config = File.join(na_gemspec.full_gem_path, na_gemspec.require_path)
-    $CPPFLAGS = " -I#{narray_config} "+$CPPFLAGS
+    require 'pathname'
+    paths = na_gemspec.require_paths.map do |path|
+      if Pathname.new(path).relative?
+        File.join(na_gemspec.full_gem_path, path)
+      else
+        path
+      end
+    end
+    find_header('narray.h', *paths)
   end
 rescue LoadError
 end

--- a/gsl-nmatrix.gemspec
+++ b/gsl-nmatrix.gemspec
@@ -31,4 +31,3 @@ Gem::Specification.new do |gem|
 
 
 end
-


### PR DESCRIPTION
Find nmatrix.h by Kernel#find_header from mkmf library, from paths returned by Gem::Specification#require_paths.

The paths are checked by Pathname#relative? and Gem::Specification#full_gem_path is prepended only if a path is a relative path.