### PR TITLE
Adapt to GSL 2.0

### DIFF
--- a/ext/gsl_native/histogram.c
+++ b/ext/gsl_native/histogram.c
@@ -1169,6 +1169,7 @@ static VALUE rb_gsl_histogram_fit_gaussian(int argc, VALUE *argv, VALUE obj)
   size_t n, dof;      /* # of data points */
   size_t p = 3;  /* # of fitting parameters */
   gsl_multifit_function_fdf f;
+  gsl_matrix *J = NULL;
   gsl_matrix *covar = NULL;
   gsl_vector *x = NULL;
   double sigma, mean, height, errs, errm, errh, chi2;
@@ -1197,6 +1198,7 @@ static VALUE rb_gsl_histogram_fit_gaussian(int argc, VALUE *argv, VALUE obj)
   hh.binend = binend;
   n = binend - binstart + 1;
 
+  J = gsl_matrix_alloc(n, p);
   covar = gsl_matrix_alloc(p, p);
 
   f.f = Gaussian_f;
@@ -1219,7 +1221,8 @@ static VALUE rb_gsl_histogram_fit_gaussian(int argc, VALUE *argv, VALUE obj)
   sigma = sqrt(gsl_vector_get(s->x, 0));
   mean = gsl_vector_get(s->x, 1);
   height = gsl_vector_get(s->x, 2)*sigma*sqrt(2*M_PI);
-  gsl_multifit_covar(s->J, 0.0, covar);
+  gsl_multifit_fdfsolver_jac(s, J);
+  gsl_multifit_covar(J, 0.0, covar);
   chi2 = gsl_pow_2(gsl_blas_dnrm2(s->f));   /* not reduced chi-square */
   dof = n - p;
   errs = sqrt(chi2/dof*gsl_matrix_get(covar, 0, 0))/sigma/2;
@@ -1305,6 +1308,7 @@ static VALUE rb_gsl_histogram_fit_rayleigh(int argc, VALUE *argv, VALUE obj)
   size_t n, dof;      /* # of data points */
   size_t p = 2;  /* # of fitting parameters */
   gsl_multifit_function_fdf f;
+  gsl_matrix *J = NULL;
   gsl_matrix *covar = NULL;
   gsl_vector *x = NULL;
   double sigma, height, errs, errh, chi2;
@@ -1332,6 +1336,7 @@ static VALUE rb_gsl_histogram_fit_rayleigh(int argc, VALUE *argv, VALUE obj)
   hh.binend = binend;
   n = binend - binstart + 1;
 
+  J = gsl_matrix_alloc(n, p);
   covar = gsl_matrix_alloc(p, p);
 
   f.f = Rayleigh_f;
@@ -1353,7 +1358,8 @@ static VALUE rb_gsl_histogram_fit_rayleigh(int argc, VALUE *argv, VALUE obj)
   } while (status == GSL_CONTINUE);
   sigma = sqrt(gsl_vector_get(s->x, 0));
   height = gsl_vector_get(s->x, 1)*sigma*sigma;
-  gsl_multifit_covar(s->J, 0.0, covar);
+  gsl_multifit_fdfsolver_jac(s, J);
+  gsl_multifit_covar(J, 0.0, covar);
   chi2 = gsl_pow_2(gsl_blas_dnrm2(s->f));   /* not reduced chi-square */
   dof = n - p;
   errs = sqrt(chi2/dof*gsl_matrix_get(covar, 0, 0))/sigma/2;
@@ -1441,6 +1447,7 @@ static VALUE rb_gsl_histogram_fit_xexponential(int argc, VALUE *argv, VALUE obj)
   size_t n, dof;      /* # of data points */
   size_t p = 2;  /* # of fitting parameters */
   gsl_multifit_function_fdf f;
+  gsl_matrix *J = NULL;
   gsl_matrix *covar = NULL;
   gsl_vector *x = NULL;
   double b, height, errs, errh, chi2;
@@ -1468,6 +1475,7 @@ static VALUE rb_gsl_histogram_fit_xexponential(int argc, VALUE *argv, VALUE obj)
   hh.binend = binend;
   n = binend - binstart + 1;
 
+  J = gsl_matrix_alloc(n, p);
   covar = gsl_matrix_alloc(p, p);
 
   f.f = xExponential_f;
@@ -1489,7 +1497,8 @@ static VALUE rb_gsl_histogram_fit_xexponential(int argc, VALUE *argv, VALUE obj)
   } while (status == GSL_CONTINUE);
   b = gsl_vector_get(s->x, 0);
   height = gsl_vector_get(s->x, 1);
-  gsl_multifit_covar(s->J, 0.0, covar);
+  gsl_multifit_fdfsolver_jac(s, J);
+  gsl_multifit_covar(J, 0.0, covar);
   chi2 = gsl_pow_2(gsl_blas_dnrm2(s->f));   /* not reduced chi-square */
   dof = n - p;
   errs = sqrt(chi2/dof*gsl_matrix_get(covar, 0, 0));

--- a/ext/gsl_native/multifit.c
+++ b/ext/gsl_native/multifit.c
@@ -324,6 +324,7 @@ static VALUE rb_gsl_multifit_fdfsolver_test_gradient(int argc, VALUE *argv, VALU
 {
   gsl_multifit_fdfsolver *solver = NULL;
   gsl_vector *g = NULL;
+  gsl_matrix *J = NULL;
   int status;
   double epsabs;
   Data_Get_Struct(obj, gsl_multifit_fdfsolver, solver);
@@ -331,7 +332,9 @@ static VALUE rb_gsl_multifit_fdfsolver_test_gradient(int argc, VALUE *argv, VALU
   case 1:
     Need_Float(argv[0]);
     g = gsl_vector_alloc(solver->x->size);
-    gsl_multifit_gradient(solver->J, solver->f, g);
+    J = gsl_matrix_alloc(solver->f->size, solver->x->size);
+    gsl_multifit_fdfsolver_jac(solver, J);
+    gsl_multifit_gradient(J, solver->f, g);
     epsabs = NUM2DBL(argv[0]);
     status = gsl_multifit_test_gradient(g, epsabs);
     gsl_vector_free(g);
@@ -353,15 +356,17 @@ static VALUE rb_gsl_multifit_fdfsolver_gradient(int argc, VALUE *argv, VALUE obj
 {
   gsl_multifit_fdfsolver *solver = NULL;
   gsl_vector *g = NULL;
+  gsl_matrix *J = gsl_matrix_alloc(solver->f->size, solver->x->size);
   // local variable "status" declared and set, but never used
   //int status;
   Data_Get_Struct(obj, gsl_multifit_fdfsolver, solver);
+  gsl_multifit_fdfsolver_jac(solver, J);
   if (argc == 1) {
     Data_Get_Vector(argv[0], g);
-    return INT2FIX(gsl_multifit_gradient(solver->J, solver->f, g));
+    return INT2FIX(gsl_multifit_gradient(J, solver->f, g));
   } else {
     g = gsl_vector_alloc(solver->x->size);
-    /*status =*/ gsl_multifit_gradient(solver->J, solver->f, g);
+    /*status =*/ gsl_multifit_gradient(J, solver->f, g);
     return Data_Wrap_Struct(cgsl_vector, 0, gsl_vector_free, g);
   }
 }
@@ -377,15 +382,17 @@ static VALUE rb_gsl_multifit_fdfsolver_covar(int argc, VALUE *argv, VALUE obj)
   Need_Float(argv[0]);
   Data_Get_Struct(obj, gsl_multifit_fdfsolver, solver);
   epsrel = NUM2DBL(argv[0]);
+  gsl_matrix *J = gsl_matrix_alloc(solver->f->size, solver->x->size);
+  gsl_multifit_fdfsolver_jac(solver, J);
   switch (argc) {
   case 1:
     covar = gsl_matrix_alloc(solver->x->size, solver->x->size);
-    /*status =*/ gsl_multifit_covar(solver->J, epsrel, covar);
+    /*status =*/ gsl_multifit_covar(J, epsrel, covar);
     return Data_Wrap_Struct(cgsl_matrix, 0, gsl_matrix_free, covar);
     break;
   case 2:
     Data_Get_Matrix(argv[1], covar);
-    return INT2FIX(gsl_multifit_covar(solver->J, epsrel, covar));
+    return INT2FIX(gsl_multifit_covar(J, epsrel, covar));
     break;
   default:
     rb_raise(rb_eArgError, "wrong number of arguments");
@@ -418,7 +425,9 @@ static VALUE rb_gsl_multifit_fdfsolver_J(VALUE obj)
 {
   gsl_multifit_fdfsolver *solver = NULL;
   Data_Get_Struct(obj, gsl_multifit_fdfsolver, solver);
-  return Data_Wrap_Struct(cgsl_matrix_view_ro, 0, NULL, solver->J);
+  gsl_matrix *J = gsl_matrix_alloc(solver->f->size, solver->x->size);
+  gsl_multifit_fdfsolver_jac(solver, J);
+  return Data_Wrap_Struct(cgsl_matrix_view_ro, 0, NULL, J);
 }
 
 /* singleton */
@@ -1699,7 +1708,9 @@ static VALUE rb_gsl_multifit_fit(int argc, VALUE *argv, VALUE klass)
   covar = gsl_matrix_alloc(p, p);
   chi2 = gsl_pow_2(gsl_blas_dnrm2(solver->f));   /* not reduced chi-square */
   dof = n - p;
-  gsl_multifit_covar(solver->J, 0.0, covar);
+  gsl_matrix *J = gsl_matrix_alloc(n,p);
+  gsl_multifit_fdfsolver_jac(solver, J);
+  gsl_multifit_covar(J, 0.0, covar);
   for (i = 0; i < p; i++)
     gsl_vector_set(verr, i, sqrt(chi2/dof*gsl_matrix_get(covar, i, i)));
   gsl_matrix_free(covar);

--- a/ext/gsl_native/sf_ellint.c
+++ b/ext/gsl_native/sf_ellint.c
@@ -82,17 +82,17 @@ static VALUE rb_gsl_sf_ellint_P_e(VALUE obj, VALUE phi, VALUE k,
 static VALUE rb_gsl_sf_ellint_D(int argc, VALUE *argv, VALUE obj)
 {
   if (argc == 3)
-    return rb_gsl_sf_eval_double3_m(gsl_sf_ellint_D, argv[0], argv[1], argv[2],
+    return rb_gsl_sf_eval_double2_m(gsl_sf_ellint_D, argv[0], argv[1],
                                     INT2FIX(GSL_PREC_DOUBLE));
   else
-    return rb_gsl_sf_eval_double3_m(gsl_sf_ellint_D, argv[0], argv[1], argv[2],
+    return rb_gsl_sf_eval_double2_m(gsl_sf_ellint_D, argv[0], argv[1],
                                     argv[3]);
 }
 
 static VALUE rb_gsl_sf_ellint_D_e(VALUE obj, VALUE phi, VALUE k,
-                                  VALUE n, VALUE m)
+                                  VALUE m)
 {
-  return rb_gsl_sf_eval_e_double3_m(gsl_sf_ellint_D_e, phi, k, n, m);
+  return rb_gsl_sf_eval_e_double2_m(gsl_sf_ellint_D_e, phi, k, m);
 }
 
 static VALUE rb_gsl_sf_ellint_RC(int argc, VALUE *argv, VALUE obj)

--- a/ext/gsl_native/sf_mathieu.c
+++ b/ext/gsl_native/sf_mathieu.c
@@ -133,11 +133,11 @@ static VALUE sf_mathieu_eval_e_int2_double2(VALUE n1, VALUE n2, VALUE qq, VALUE 
 /**********/
 static VALUE rb_gsl_sf_mathieu_a_e(VALUE module, VALUE order, VALUE qq)
 {
-  return rb_gsl_sf_eval_e_int_double(gsl_sf_mathieu_a, order, qq);
+  return rb_gsl_sf_eval_e_int_double(gsl_sf_mathieu_a_e, order, qq);
 }
 static VALUE rb_gsl_sf_mathieu_a(VALUE module, VALUE order, VALUE qq)
 {
-  return sf_mathieu_eval(order, qq, gsl_sf_mathieu_a);
+  return sf_mathieu_eval(order, qq, gsl_sf_mathieu_a_e);
 }
 static VALUE rb_gsl_sf_mathieu_a_array(VALUE module, int argc, VALUE *argv)
 {
@@ -145,11 +145,11 @@ static VALUE rb_gsl_sf_mathieu_a_array(VALUE module, int argc, VALUE *argv)
 }
 static VALUE rb_gsl_sf_mathieu_b_e(VALUE module, VALUE order, VALUE qq)
 {
-  return rb_gsl_sf_eval_e_int_double(gsl_sf_mathieu_b, order, qq);
+  return rb_gsl_sf_eval_e_int_double(gsl_sf_mathieu_b_e, order, qq);
 }
 static VALUE rb_gsl_sf_mathieu_b(VALUE module, VALUE order, VALUE qq)
 {
-  return sf_mathieu_eval(order, qq, gsl_sf_mathieu_b);
+  return sf_mathieu_eval(order, qq, gsl_sf_mathieu_b_e);
 }
 static VALUE rb_gsl_sf_mathieu_b_array(VALUE module, int argc, VALUE *argv)
 {
@@ -157,11 +157,11 @@ static VALUE rb_gsl_sf_mathieu_b_array(VALUE module, int argc, VALUE *argv)
 }
 static VALUE rb_gsl_sf_mathieu_ce_e(VALUE module, VALUE order, VALUE qq, VALUE zz)
 {
-  return sf_mathieu_eval_e_int_double2(order, qq, zz, gsl_sf_mathieu_ce);
+  return sf_mathieu_eval_e_int_double2(order, qq, zz, gsl_sf_mathieu_ce_e);
 }
 static VALUE rb_gsl_sf_mathieu_ce(VALUE module, VALUE order, VALUE qq, VALUE zz)
 {
-  return sf_mathieu_eval_int_double2(order, qq, zz, gsl_sf_mathieu_ce);
+  return sf_mathieu_eval_int_double2(order, qq, zz, gsl_sf_mathieu_ce_e);
 }
 static VALUE rb_gsl_sf_mathieu_ce_array(VALUE module, int argc, VALUE *argv)
 {
@@ -169,11 +169,11 @@ static VALUE rb_gsl_sf_mathieu_ce_array(VALUE module, int argc, VALUE *argv)
 }
 static VALUE rb_gsl_sf_mathieu_se_e(VALUE module, VALUE order, VALUE qq, VALUE zz)
 {
-  return sf_mathieu_eval_e_int_double2(order, qq, zz, gsl_sf_mathieu_se);
+  return sf_mathieu_eval_e_int_double2(order, qq, zz, gsl_sf_mathieu_se_e);
 }
 static VALUE rb_gsl_sf_mathieu_se(VALUE module, VALUE order, VALUE qq, VALUE zz)
 {
-  return sf_mathieu_eval_int_double2(order, qq, zz, gsl_sf_mathieu_se);
+  return sf_mathieu_eval_int_double2(order, qq, zz, gsl_sf_mathieu_se_e);
 }
 static VALUE rb_gsl_sf_mathieu_se_array(VALUE module, int argc, VALUE *argv)
 {
@@ -183,11 +183,11 @@ static VALUE rb_gsl_sf_mathieu_se_array(VALUE module, int argc, VALUE *argv)
 /*****/
 static VALUE rb_gsl_sf_mathieu_Mc_e(VALUE module, VALUE n1, VALUE n2, VALUE q, VALUE x)
 {
-  return sf_mathieu_eval_e_int2_double2(n1, n2, q, x, gsl_sf_mathieu_Mc);
+  return sf_mathieu_eval_e_int2_double2(n1, n2, q, x, gsl_sf_mathieu_Mc_e);
 }
 static VALUE rb_gsl_sf_mathieu_Mc(VALUE module, VALUE n1, VALUE n2, VALUE q, VALUE x)
 {
-  return sf_mathieu_eval2(n1, n2, q, x, gsl_sf_mathieu_Mc);
+  return sf_mathieu_eval2(n1, n2, q, x, gsl_sf_mathieu_Mc_e);
 }
 static VALUE rb_gsl_sf_mathieu_Mc_array(VALUE module, int argc, VALUE *argv)
 {
@@ -195,11 +195,11 @@ static VALUE rb_gsl_sf_mathieu_Mc_array(VALUE module, int argc, VALUE *argv)
 }
 static VALUE rb_gsl_sf_mathieu_Ms_e(VALUE module, VALUE n1, VALUE n2, VALUE q, VALUE x)
 {
-  return sf_mathieu_eval_e_int2_double2(n1, n2, q, x, gsl_sf_mathieu_Ms);
+  return sf_mathieu_eval_e_int2_double2(n1, n2, q, x, gsl_sf_mathieu_Ms_e);
 }
 static VALUE rb_gsl_sf_mathieu_Ms(VALUE module, VALUE n1, VALUE n2, VALUE q, VALUE x)
 {
-  return sf_mathieu_eval2(n1, n2, q, x, gsl_sf_mathieu_Ms);
+  return sf_mathieu_eval2(n1, n2, q, x, gsl_sf_mathieu_Ms_e);
 }
 static VALUE rb_gsl_sf_mathieu_Ms_array(VALUE module, int argc, VALUE *argv)
 {

--- a/ext/gsl_native/tamu_anova.c
+++ b/ext/gsl_native/tamu_anova.c
@@ -32,7 +32,7 @@ VALUE rb_tamu_anova_alloc(int argc, VALUE *argv, VALUE klass)
 VALUE rb_tamu_anova_printtable(VALUE *vTable)
 {
   struct tamu_anova_table *table;
-  Data_Get_Struct(vTable, struct tamu_anova_table, table);
+  Data_Get_Struct(*vTable, struct tamu_anova_table, table);
   tamu_anova_printtable(*table);
   return Qtrue;
 }


### PR DESCRIPTION
The following modifications allows one to compile and ruby rb-gsl against GSL v2.
- change the way jacobians of fdfsolvers are computed as they are no more accessible as members of the structure
- some elliptic functions return error code change their name, elliptic D function dropped the unused parameter n
- fix a compiler warning about a pointer being passed instead of the value it was pointing to.

The files build without warning and test pass with ruby2.2 and ruby2.3

Let me know if you want me to modify or correct things  in this PR.

This allows at least Debian to fix the transition of this package to GSL 2, and thus fixes #24 and #25 

Thanks!
