### PR TITLE
Fix the behavior of GSL::Sf:gamma_inc and gsl mode selection for all special functions.

### DIFF
--- a/ext/gsl_native/sf_gamma.c
+++ b/ext/gsl_native/sf_gamma.c
@@ -239,7 +239,7 @@ static VALUE rb_gsl_sf_gamma_inc_P_e(VALUE obj, VALUE a, VALUE x)
 
 static VALUE rb_gsl_sf_gamma_inc(VALUE obj, VALUE a, VALUE x)
 {
-  return rb_gsl_sf_eval_double_double(gsl_sf_gamma_inc_P, a, x);
+  return rb_gsl_sf_eval_double_double(gsl_sf_gamma_inc, a, x);
 }
 
 static VALUE rb_gsl_sf_gamma_inc_e(VALUE obj, VALUE a, VALUE x)


### PR DESCRIPTION
This fixes a typo that caused GSL::Sf::gamma_inc to compute gamma_inc_P. Additionally, it adds a test for "natural form" variants of special functions that would have detected this issue earlier.

To make the test actually pass I had to go down the rabbit hole and fix the handling of the mode argument which was totally broken for several rb_gsl_sf_eval* functions. While at it, I refactored the mode selection code into its own function, instead of it being duplicated everywhere.