### PR TITLE
String handling fixes and simplifications

### DIFF
--- a/ext/gsl_native/block_source.h
+++ b/ext/gsl_native/block_source.h
@@ -138,7 +138,6 @@ static VALUE FUNCTION(rb_gsl_block,fscanf)(VALUE obj, VALUE io)
 static VALUE FUNCTION(rb_gsl_block,to_s)(VALUE obj)
 {
   GSL_TYPE(gsl_block) *v = NULL;
-  char buf[32];
   size_t i, n;
   VALUE str;
   Data_Get_Struct(obj, GSL_TYPE(gsl_block), v);
@@ -146,16 +145,13 @@ static VALUE FUNCTION(rb_gsl_block,to_s)(VALUE obj)
   n = v->size;
   if (rb_obj_is_kind_of(obj, cgsl_block_complex)) n *= 2;
   for (i = 0; i < n; i++) {
-    sprintf(buf,  PRINTF_FORMAT, (TYPE2) v->data[i]);
-    rb_str_cat(str, buf, strlen(buf));
+    rb_str_catf(str, PRINTF_FORMAT, (TYPE2) v->data[i]);
     if (i == SHOW_ELM && i != v->size-1) {
-      strcpy(buf, "... ");
-      rb_str_cat(str, buf, strlen(buf));
+      rb_str_cat2(str, "... ");
       break;
     }
   }
-  sprintf(buf, "]");
-  rb_str_cat(str, buf, strlen(buf));
+  rb_str_cat2(str, "]");
   return str;
 }
 #undef SHOW_ELM
@@ -164,9 +160,7 @@ static VALUE FUNCTION(rb_gsl_block,to_s)(VALUE obj)
 static VALUE FUNCTION(rb_gsl_block,inspect)(VALUE obj)
 {
   VALUE str;
-  char buf[64];
-  sprintf(buf, "%s\n", rb_class2name(CLASS_OF(obj)));
-  str = rb_str_new2(buf);
+  str = rb_sprintf("%s\n", rb_class2name(CLASS_OF(obj)));
   return rb_str_concat(str, FUNCTION(rb_gsl_block,to_s)(obj));
 }
 

--- a/ext/gsl_native/complex.c
+++ b/ext/gsl_native/complex.c
@@ -175,7 +175,6 @@ static VALUE rb_gsl_complex_printf(VALUE obj, VALUE s)
   return obj;
 }
 
-static VALUE rb_gsl_complex_return_double(double (*func)(gsl_complex), VALUE obj);
 static VALUE rb_gsl_complex_return_double(double (*func)(gsl_complex), VALUE obj)
 {
   gsl_complex *c = NULL;
@@ -862,19 +861,14 @@ static VALUE rb_gsl_complex_zero(VALUE obj)
 
 static VALUE rb_gsl_complex_to_s(VALUE obj)
 {
-  char buf[256];
   gsl_complex *z;
   Data_Get_Struct(obj, gsl_complex, z);
-  sprintf(buf, "[ %4.3e %4.3e ]", GSL_REAL(*z), GSL_IMAG(*z));
-  return rb_str_new2(buf);
+  return rb_sprintf("[ %4.3e %4.3e ]", GSL_REAL(*z), GSL_IMAG(*z));
 }
 
 static VALUE rb_gsl_complex_inspect(VALUE obj)
 {
-  char buf[256];
-  VALUE str;
-  sprintf(buf, "%s\n", rb_class2name(CLASS_OF(obj)));
-  str = rb_str_new2(buf);
+  VALUE str = rb_sprintf("%s\n", rb_class2name(CLASS_OF(obj)));
   return rb_str_concat(str, rb_gsl_complex_to_s(obj));
 }
 

--- a/ext/gsl_native/gsl.c
+++ b/ext/gsl_native/gsl.c
@@ -22,9 +22,7 @@ static void rb_gsl_define_methods(VALUE module);
 
 static VALUE rb_gsl_object_inspect(VALUE obj)
 {
-  char buf[256];
-  sprintf(buf, "%s", rb_class2name(CLASS_OF(obj)));
-  return rb_str_new2(buf);
+  return rb_sprintf("%s", rb_class2name(CLASS_OF(obj)));
 }
 
 static VALUE rb_gsl_call_rescue(VALUE obj)
@@ -44,15 +42,15 @@ static VALUE rb_gsl_call_size(VALUE obj)
 
 static VALUE rb_gsl_object_info(VALUE obj)
 {
-  char buf[256];
-  VALUE s;
-  sprintf(buf, "Class:      %s\n", rb_class2name(CLASS_OF(obj)));
-  sprintf(buf, "%sSuperClass: %s\n", buf, rb_class2name(RCLASS_SUPER(CLASS_OF(obj))));
+  VALUE buf, s;
+  buf = rb_sprintf("Class:      %s\n", rb_class2name(CLASS_OF(obj)));
+  rb_str_catf(buf, "SuperClass: %s\n", rb_class2name(RCLASS_SUPER(CLASS_OF(obj))));
   s = rb_rescue(rb_gsl_call_name, obj, rb_gsl_call_rescue, obj);
-  if (s) sprintf(buf, "%sType:       %s\n", buf, STR2CSTR(s));
+  if (s) rb_str_catf(buf, "Type:       %s\n", STR2CSTR(s));
+  RB_GC_GUARD(s);
   s = rb_rescue(rb_gsl_call_size, obj, rb_gsl_call_rescue, obj);
-  if (s) sprintf(buf, "%sSize:       %d\n", buf, (int) FIX2INT(s));
-  return rb_str_new2(buf);
+  if (s) rb_str_catf(buf, "Size:       %d\n", (int) FIX2INT(s));
+  return buf;
 }
 
 static VALUE rb_gsl_not_implemeted(VALUE obj)

--- a/ext/gsl_native/histogram.c
+++ b/ext/gsl_native/histogram.c
@@ -1548,10 +1548,10 @@ static VALUE rb_gsl_histogram_fit_xexponential(int argc, VALUE *argv, VALUE obj)
 
 static VALUE rb_gsl_histogram_fit(int argc, VALUE *argv, VALUE obj)
 {
-  char fittype[32];
+  char *fittype;
   if (argc < 1) rb_raise(rb_eArgError, "too few arguments");
   Check_Type(argv[0], T_STRING);
-  strcpy(fittype, STR2CSTR(argv[0]));
+  fittype = STR2CSTR(argv[0]);
   if (str_head_grep(fittype, "exp") == 0) {
     return rb_gsl_histogram_fit_exponential(argc-1, argv+1, obj);
   } else if (str_head_grep(fittype, "power") == 0) {
@@ -1566,6 +1566,7 @@ static VALUE rb_gsl_histogram_fit(int argc, VALUE *argv, VALUE obj)
     rb_raise(rb_eRuntimeError,
              "unknown fitting type %s (exp, power, gaus expected)", fittype);
   }
+  RB_GC_GUARD(argv[0]);
   return Qnil;
 }
 

--- a/ext/gsl_native/include/rb_gsl_common.h
+++ b/ext/gsl_native/include/rb_gsl_common.h
@@ -315,7 +315,7 @@ int str_tail_grep(const char *s0, const char *s1);
 int str_head_grep(const char *s0, const char *s1);
 
 #ifndef STR2CSTR
-#define STR2CSTR StringValuePtr
+#define STR2CSTR StringValueCStr
 #endif
 
 #ifndef RCLASS_SUPER

--- a/ext/gsl_native/interp.c
+++ b/ext/gsl_native/interp.c
@@ -398,7 +398,7 @@ static VALUE rb_gsl_interp_eval_integ_e(VALUE obj, VALUE xxa, VALUE yya,
 const gsl_interp_type* get_interp_type(VALUE t)
 {
   int type;
-  char name[32];
+  char *name;
   switch (TYPE(t)) {
   case T_FIXNUM:
     type = FIX2INT(t);
@@ -415,7 +415,7 @@ const gsl_interp_type* get_interp_type(VALUE t)
     }
     break;
   case T_STRING:
-    strcpy(name, STR2CSTR(t));
+    name = STR2CSTR(t);
     if (str_tail_grep(name, "linear") == 0) {
       return gsl_interp_linear;
     } else if (str_tail_grep(name, "polynomial") == 0) {
@@ -436,20 +436,21 @@ const gsl_interp_type* get_interp_type(VALUE t)
     rb_raise(rb_eTypeError, "Unknown type");
     break;
   }
+  RB_GC_GUARD(t);
 }
 
 static VALUE rb_gsl_interp_info(VALUE obj)
 {
   rb_gsl_interp *p;
-  char buf[256];
+  VALUE buf;
   Data_Get_Struct(obj, rb_gsl_interp, p);
-  sprintf(buf, "Class:      %s\n", rb_class2name(CLASS_OF(obj)));
-  sprintf(buf, "%sSuperClass: %s\n", buf, rb_class2name(RCLASS_SUPER(CLASS_OF(obj))));
-  sprintf(buf, "%sType:       %s\n", buf, gsl_interp_name(p->p));
-  sprintf(buf, "%sxmin:       %f\n", buf, p->p->xmin);
-  sprintf(buf, "%sxmax:       %f\n", buf, p->p->xmax);
-  sprintf(buf, "%sSize:       %d\n", buf, (int) p->p->size);
-  return rb_str_new2(buf);
+  buf = rb_sprintf("Class:      %s\n", rb_class2name(CLASS_OF(obj)));
+  rb_str_catf(buf, "SuperClass: %s\n", rb_class2name(RCLASS_SUPER(CLASS_OF(obj))));
+  rb_str_catf(buf, "Type:       %s\n", gsl_interp_name(p->p));
+  rb_str_catf(buf, "xmin:       %f\n", p->p->xmin);
+  rb_str_catf(buf, "xmax:       %f\n", p->p->xmax);
+  rb_str_catf(buf, "Size:       %d\n", (int) p->p->size);
+  return buf;
 }
 
 static void rb_gsl_interp_define_const(VALUE klass)

--- a/ext/gsl_native/interp2d.c
+++ b/ext/gsl_native/interp2d.c
@@ -15,7 +15,7 @@ VALUE cgsl_interp2d_accel; /* this is used also in spline2d.c */
 EXTERN VALUE cgsl_vector, cgsl_matrix;
 
 static VALUE rb_gsl_interp2d_alloc(int argc, VALUE *argv, VALUE self)
-{ 
+{
   rb_gsl_interp2d *sp = NULL;
   const gsl_interp2d_type *T = NULL;
   double *xptr = NULL, *yptr = NULL, *zptr = NULL;
@@ -63,8 +63,8 @@ static VALUE rb_gsl_interp2d_init(VALUE self, VALUE xarr, VALUE yarr, VALUE zarr
 }
 
 static VALUE rb_gsl_interp_evaluate(
-  VALUE self, VALUE xarr, VALUE yarr, VALUE zarr, VALUE xx, VALUE yy, 
-    double (*eval)(const gsl_interp2d * interp, 
+  VALUE self, VALUE xarr, VALUE yarr, VALUE zarr, VALUE xx, VALUE yy,
+    double (*eval)(const gsl_interp2d * interp,
       const double xa[], const double ya[], const double za[],
       const double x, const double y, gsl_interp_accel * xacc,
       gsl_interp_accel * yacc))
@@ -77,7 +77,7 @@ static VALUE rb_gsl_interp_evaluate(
     xx = yy;
     yy = temp;
   }
-  
+
   rb_gsl_interp2d *rgi = NULL;
   double *xptr = NULL, *yptr = NULL, *zptr = NULL;
   gsl_vector *vx = NULL, *vy = NULL, *vnew = NULL;
@@ -89,19 +89,19 @@ static VALUE rb_gsl_interp_evaluate(
   Data_Get_Struct(self, rb_gsl_interp2d, rgi);
   xptr = get_vector_ptr(xarr, &stridex, &xsize);
   if (xsize != rgi->p->xsize ) {
-    rb_raise(rb_eTypeError, "size mismatch (xa:%d != %d)",  (int) xsize, 
+    rb_raise(rb_eTypeError, "size mismatch (xa:%d != %d)",  (int) xsize,
       (int) rgi->p->xsize);
   }
 
   yptr = get_vector_ptr(yarr, &stridey, &ysize);
   if (ysize != rgi->p->ysize ) {
-    rb_raise(rb_eTypeError, "size mismatch (ya:%d != %d)", (int) ysize, 
+    rb_raise(rb_eTypeError, "size mismatch (ya:%d != %d)", (int) ysize,
       (int) rgi->p->ysize);
   }
 
   zptr = get_vector_ptr(zarr, &stridez, &zsize);
   if (zsize != xsize*ysize ) {
-    rb_raise(rb_eTypeError, "size mismatch (za:%d != %d)", (int) zsize, 
+    rb_raise(rb_eTypeError, "size mismatch (za:%d != %d)", (int) zsize,
       (int) xsize*ysize);
   }
 
@@ -145,7 +145,7 @@ static VALUE rb_gsl_interp_evaluate(
       vnew = gsl_vector_alloc(vx->size);
 
       for (i = 0; i < vx->size; i++) {
-        val = (*eval)(rgi->p, xptr, yptr, zptr, gsl_vector_get(vx, i), 
+        val = (*eval)(rgi->p, xptr, yptr, zptr, gsl_vector_get(vx, i),
           gsl_vector_get(vy, i), rgi->xacc, rgi->yacc);
         gsl_vector_set(vnew, i, val);
       }
@@ -199,9 +199,9 @@ static void rb_gsl_interp2d_define_const(VALUE self)
 }
 
 const gsl_interp2d_type* get_interp2d_type(VALUE t)
-{ 
+{
   int type;
-  char name[32];
+  char *name;
 
   switch(TYPE(t)) {
     case T_FIXNUM:
@@ -212,9 +212,9 @@ const gsl_interp2d_type* get_interp2d_type(VALUE t)
         case 1: return gsl_interp2d_bilinear; break;
         default:
           rb_raise(rb_eRuntimeError, "Cannot recognize type %d.\n", type);
-      } 
+      }
     case T_STRING:
-      strcpy(name, STR2CSTR(t));
+      name = STR2CSTR(t);
 
       if (str_tail_grep("bicubic", name) == 0) {
         return gsl_interp2d_bicubic;
@@ -228,24 +228,25 @@ const gsl_interp2d_type* get_interp2d_type(VALUE t)
     default:
       rb_raise(rb_eRuntimeError, "Unknown type.");
   }
+  RB_GC_GUARD(t);
 }
 
 static VALUE rb_gsl_interp2d_info(VALUE self)
 {
   rb_gsl_interp2d *p;
-  char buf[256];
+  VALUE buf;
   Data_Get_Struct(self, rb_gsl_interp2d, p);
-  sprintf(buf, "Class:      %s\n", rb_class2name(CLASS_OF(self)));
-  sprintf(buf, "%sSuperClass: %s\n", buf, rb_class2name(RCLASS_SUPER(CLASS_OF(self))));
-  sprintf(buf, "%sType:       %s\n", buf, gsl_interp2d_name(p->p));
-  sprintf(buf, "%sxmin:       %f\n", buf, p->p->xmin);
-  sprintf(buf, "%sxmax:       %f\n", buf, p->p->xmax);
-  sprintf(buf, "%symin:       %f\n", buf, p->p->ymin);
-  sprintf(buf, "%symax:       %f\n", buf, p->p->ymax);
-  sprintf(buf, "%sxsize:       %d\n", buf, (int) p->p->xsize);
-  sprintf(buf, "%sysize:       %d\n", buf, (int) p->p->ysize);
+  buf = rb_sprintf("Class:      %s\n", rb_class2name(CLASS_OF(self)));
+  rb_str_catf(buf, "SuperClass: %s\n", rb_class2name(RCLASS_SUPER(CLASS_OF(self))));
+  rb_str_catf(buf, "Type:       %s\n", gsl_interp2d_name(p->p));
+  rb_str_catf(buf, "xmin:       %f\n", p->p->xmin);
+  rb_str_catf(buf, "xmax:       %f\n", p->p->xmax);
+  rb_str_catf(buf, "ymin:       %f\n", p->p->ymin);
+  rb_str_catf(buf, "ymax:       %f\n", p->p->ymax);
+  rb_str_catf(buf, "xsize:       %d\n", (int) p->p->xsize);
+  rb_str_catf(buf, "ysize:       %d\n", (int) p->p->ysize);
 
-  return rb_str_new2(buf);
+  return buf;
 }
 
 void Init_gsl_interp2d(VALUE module)

--- a/ext/gsl_native/matrix_complex.c
+++ b/ext/gsl_native/matrix_complex.c
@@ -600,7 +600,6 @@ static VALUE rb_gsl_matrix_complex_print(VALUE obj)
 static VALUE rb_gsl_matrix_complex_to_s(int argc, VALUE *argv, VALUE obj)
 {
   gsl_matrix_complex *m = NULL;
-  char buf[64];
   size_t i, j;
   VALUE str;
   gsl_complex z;
@@ -624,9 +623,8 @@ static VALUE rb_gsl_matrix_complex_to_s(int argc, VALUE *argv, VALUE obj)
     }
     for (j = 0; j < m->size2; j++) {
       z = gsl_matrix_complex_get(m, i, j);
-      sprintf(buf,
-              "%s[ %4.3e %4.3e ]", (j==0) ? "" : " ", GSL_REAL(z), GSL_IMAG(z));
-      rb_str_cat(str, buf, strlen(buf));
+      rb_str_catf(str,
+                  "%s[ %4.3e %4.3e ]", (j==0) ? "" : " ", GSL_REAL(z), GSL_IMAG(z));
       // if too many cols
       if ((int) j >= max_cols-1 && j != m->size2-1) {
         rb_str_cat(str, " ...", 4);
@@ -646,12 +644,11 @@ static VALUE rb_gsl_matrix_complex_to_s(int argc, VALUE *argv, VALUE obj)
 static VALUE rb_gsl_matrix_complex_inspect(int argc, VALUE *argv, VALUE obj)
 {
   VALUE str;
-  char buf[128];
   gsl_matrix_complex *m;
 
   Data_Get_Struct(obj, gsl_matrix_complex, m);
-  sprintf(buf, "#<%s[%lu,%lu]:%#lx>\n", rb_class2name(CLASS_OF(obj)), m->size1, m->size2, NUM2ULONG(rb_obj_id(obj)));
-  str = rb_str_new2(buf);
+  str = rb_sprintf("#<%s[%lu,%lu]:%#lx>\n", rb_class2name(CLASS_OF(obj)),
+                   m->size1, m->size2, NUM2ULONG(rb_obj_id(obj)));
   return rb_str_concat(str, rb_gsl_matrix_complex_to_s(argc, argv, obj));
 }
 

--- a/ext/gsl_native/matrix_source.h
+++ b/ext/gsl_native/matrix_source.h
@@ -865,7 +865,7 @@ static VALUE FUNCTION(rb_gsl_matrix,print)(VALUE obj)
 static VALUE FUNCTION(rb_gsl_matrix,to_s)(VALUE obj)
 {
   GSL_TYPE(gsl_matrix) *m = NULL;
-  char buf[32], format[32], format2[32];
+  char format[32], format2[32];
   size_t i, j;
   VALUE str;
   BASE x;
@@ -891,33 +891,27 @@ static VALUE FUNCTION(rb_gsl_matrix,to_s)(VALUE obj)
   str = rb_str_new2("[ ");
   for (i = 0; i < m->size1; i++) {
     if (i != 0) {
-      strcpy(buf, "  ");
-      rb_str_cat(str, buf, strlen(buf));
+      rb_str_cat2(str, "  ");
     }
     for (j = 0; j < m->size2; j++) {
       x = FUNCTION(gsl_matrix,get)(m, i, j);
       if (x < 0)
-        sprintf(buf, format, x);
+        rb_str_catf(str, format, x);
       else
-        sprintf(buf, format2, x);
-      rb_str_cat(str, buf, strlen(buf));
+        rb_str_catf(str, format2, x);
       if ((int) j >= (55/dig)) {
-        strcpy(buf, "... ");
-        rb_str_cat(str, buf, strlen(buf));
+        rb_str_cat2(str, "... ");
         break;
       }
     }
     if (i >= 20) {
-      strcpy(buf, "\n  ... ]");
-      rb_str_cat(str, buf, strlen(buf));
+      rb_str_cat2(str, "\n  ... ]");
       break;
     }
     if (i == m->size1 - 1) {
-      strcpy(buf, "]");
-      rb_str_cat(str, buf, strlen(buf));
+      rb_str_cat2(str, "]");
     } else {
-      strcpy(buf, "\n");
-      rb_str_cat(str, buf, strlen(buf));
+      rb_str_cat2(str, "\n");
     }
   }
   return str;
@@ -926,10 +920,7 @@ static VALUE FUNCTION(rb_gsl_matrix,to_s)(VALUE obj)
 
 static VALUE FUNCTION(rb_gsl_matrix,inspect)(VALUE obj)
 {
-  VALUE str;
-  char buf[64];
-  sprintf(buf, "%s\n", rb_class2name(CLASS_OF(obj)));
-  str = rb_str_new2(buf);
+  VALUE str = rb_sprintf("%s\n", rb_class2name(CLASS_OF(obj)));
   return rb_str_concat(str, FUNCTION(rb_gsl_matrix,to_s)(obj));
 }
 
@@ -2061,13 +2052,13 @@ static VALUE FUNCTION(rb_gsl_matrix,block)(VALUE obj)
 static VALUE FUNCTION(rb_gsl_matrix,info)(VALUE obj)
 {
   GSL_TYPE(gsl_matrix) *m;
-  char buf[256];
+  VALUE buf;
   Data_Get_Struct(obj, GSL_TYPE(gsl_matrix), m);
-  sprintf(buf, "Class:      %s\n", rb_class2name(CLASS_OF(obj)));
-  sprintf(buf, "%sSuperClass: %s\n", buf, rb_class2name(RCLASS_SUPER(CLASS_OF(obj))));
-  sprintf(buf, "%sDimension:  %dx%d\n", buf, (int) m->size1, (int) m->size2);
-  sprintf(buf, "%sSize:       %d\n", buf, (int) (m->size1*m->size2));
-  return rb_str_new2(buf);
+  buf = rb_sprintf("Class:      %s\n", rb_class2name(CLASS_OF(obj)));
+  rb_str_catf(buf, "SuperClass: %s\n", rb_class2name(RCLASS_SUPER(CLASS_OF(obj))));
+  rb_str_catf(buf, "Dimension:  %dx%d\n", (int) m->size1, (int) m->size2);
+  rb_str_catf(buf, "Size:       %d\n", (int) (m->size1*m->size2));
+  return buf;
 }
 
 static VALUE FUNCTION(rb_gsl_matrix,any)(VALUE obj)

--- a/ext/gsl_native/min.c
+++ b/ext/gsl_native/min.c
@@ -24,10 +24,10 @@ static const gsl_min_fminimizer_type* rb_gsl_min_fminimizer_type_get(VALUE t);
 
 static const gsl_min_fminimizer_type* rb_gsl_min_fminimizer_type_get(VALUE t)
 {
-  char name[32];
+  char *name;
   switch (TYPE(t)) {
   case T_STRING:
-    strcpy(name, STR2CSTR(t));
+    name = STR2CSTR(t);
     if (str_tail_grep(name, "goldensection") == 0)
       return gsl_min_fminimizer_goldensection;
     else if (str_tail_grep(name, "brent") == 0)
@@ -59,6 +59,7 @@ static const gsl_min_fminimizer_type* rb_gsl_min_fminimizer_type_get(VALUE t)
              rb_class2name(CLASS_OF(t)));
     break;
   }
+  RB_GC_GUARD(t);
 }
 
 static VALUE rb_gsl_min_fminimizer_new(VALUE klass, VALUE t)

--- a/ext/gsl_native/monte.c
+++ b/ext/gsl_native/monte.c
@@ -432,7 +432,7 @@ static VALUE rb_gsl_monte_vegas_integrate(int argc, VALUE *argv, VALUE obj)
 
 static int get_monte_type(VALUE vt)
 {
-  char name[32];
+  char *name;
   if (rb_obj_is_kind_of(vt, cgsl_monte_plain)) return GSL_MONTE_PLAIN_STATE;
   else if (rb_obj_is_kind_of(vt, cgsl_monte_miser)) return GSL_MONTE_MISER_STATE;
   else if (rb_obj_is_kind_of(vt, cgsl_monte_vegas)) return GSL_MONTE_VEGAS_STATE;
@@ -441,7 +441,7 @@ static int get_monte_type(VALUE vt)
   }
   switch(TYPE(vt)) {
   case T_STRING:
-    strcpy(name, STR2CSTR(vt));
+    name = STR2CSTR(vt);
     if (str_tail_grep(name, "plain") == 0) {
       return GSL_MONTE_PLAIN_STATE + 100;
     } else if (str_tail_grep(name, "miser") == 0) {
@@ -459,6 +459,7 @@ static int get_monte_type(VALUE vt)
     rb_raise(rb_eTypeError, "String or Fixnum expected");
     break;
   }
+  RB_GC_GUARD(vt);
   /* wrong argument if reach here */
   rb_raise(rb_eArgError, "wrong argument");
 }

--- a/ext/gsl_native/multimin.c
+++ b/ext/gsl_native/multimin.c
@@ -443,10 +443,10 @@ static void define_const(VALUE klass1, VALUE klass2)
 
 static const gsl_multimin_fdfminimizer_type* get_fdfminimizer_type(VALUE t)
 {
-  char name[64];
+  char *name;
   switch (TYPE(t)) {
   case T_STRING:
-    strcpy(name, STR2CSTR(t));
+    name = STR2CSTR(t);
     if (str_tail_grep(name, "conjugate_fr") == 0)
       return gsl_multimin_fdfminimizer_conjugate_fr;
     else if (str_tail_grep(name, "conjugate_pr") == 0)
@@ -481,6 +481,7 @@ static const gsl_multimin_fdfminimizer_type* get_fdfminimizer_type(VALUE t)
     rb_raise(rb_eTypeError, "type is given by a String or a Fixnum");
     break;
   }
+  RB_GC_GUARD(t);
 }
 
 static VALUE rb_gsl_fdfminimizer_new(VALUE klass, VALUE t, VALUE n)
@@ -587,11 +588,11 @@ static VALUE rb_gsl_multimin_test_gradient(VALUE obj, VALUE gg, VALUE ea)
 /*****/
 static const gsl_multimin_fminimizer_type* get_fminimizer_type(VALUE t)
 {
-  char name[64];
+  char *name;
 
   switch (TYPE(t)) {
   case T_STRING:
-    strcpy(name, STR2CSTR(t));
+    name = STR2CSTR(t);
     if (str_tail_grep(name, "nmsimplex") == 0)
       return gsl_multimin_fminimizer_nmsimplex;
     if (str_tail_grep(name, "nmsimplex2rand") == 0)
@@ -615,6 +616,7 @@ static const gsl_multimin_fminimizer_type* get_fminimizer_type(VALUE t)
              rb_class2name(CLASS_OF(t)));
     break;
   }
+  RB_GC_GUARD(t);
 }
 
 static VALUE rb_gsl_fminimizer_new(VALUE klass, VALUE t, VALUE n)
@@ -775,4 +777,3 @@ void Init_gsl_multimin(VALUE module)
 #ifdef CHECK_MULTIMIN_FUNCTION_FDF
 #undef CHECK_MULTIMIN_FUNCTION_FDF
 #endif
-

--- a/ext/gsl_native/multimin_fsdf.c
+++ b/ext/gsl_native/multimin_fsdf.c
@@ -13,10 +13,10 @@ extern VALUE cgsl_multimin_function_fdf;
 
 static const gsl_multimin_fsdfminimizer_type* get_fsdfminimizer_type(VALUE t)
 {
-  char name[64];
+  char *name;
   switch (TYPE(t)) {
   case T_STRING:
-    strcpy(name, STR2CSTR(t));
+    name = STR2CSTR(t);
     if (strcmp(name, "bundle") == 0 || strcmp(name, "bundle_method") == 0)
       return gsl_multimin_fsdfminimizer_bundle_method;
     else
@@ -26,6 +26,7 @@ static const gsl_multimin_fsdfminimizer_type* get_fsdfminimizer_type(VALUE t)
     rb_raise(rb_eTypeError, "type is given by a String or a Fixnum");
     break;
   }
+  RB_GC_GUARD(t);
 }
 
 static VALUE rb_gsl_fsdfminimizer_alloc(VALUE klass, VALUE t, VALUE n)

--- a/ext/gsl_native/multiroots.c
+++ b/ext/gsl_native/multiroots.c
@@ -427,10 +427,10 @@ static void multiroot_define_const(VALUE klass1, VALUE klass2)
 #include <string.h>
 static const gsl_multiroot_fsolver_type* get_fsolver_type(VALUE t)
 {
-  char name[32];
+  char *name;
   switch (TYPE(t)) {
   case T_STRING:
-    strcpy(name,STR2CSTR(t));
+    name = STR2CSTR(t);
     if (str_tail_grep(name, "hybrids") == 0) return gsl_multiroot_fsolver_hybrids;
     else if (str_tail_grep(name, "hybrid") == 0) return gsl_multiroot_fsolver_hybrid;
     else if (str_tail_grep(name, "dnewton") == 0) return gsl_multiroot_fsolver_dnewton;
@@ -452,14 +452,15 @@ static const gsl_multiroot_fsolver_type* get_fsolver_type(VALUE t)
     rb_raise(rb_eTypeError, "wrong type argument (Fixnum or String expected)");
     break;
   }
+  RB_GC_GUARD(t);
 }
 
 static const gsl_multiroot_fdfsolver_type* get_fdfsolver_type(VALUE t)
 {
-  char name[32];
+  char *name;
   switch (TYPE(t)) {
   case T_STRING:
-    strcpy(name,STR2CSTR(t));
+    name = STR2CSTR(t);
     if (str_tail_grep(name, "hybridsj") == 0) return gsl_multiroot_fdfsolver_hybridsj;
     else if (str_tail_grep(name, "hybridj") == 0) return gsl_multiroot_fdfsolver_hybridj;
     else if (str_tail_grep(name, "gnewton") == 0) return gsl_multiroot_fdfsolver_gnewton;
@@ -481,6 +482,7 @@ static const gsl_multiroot_fdfsolver_type* get_fdfsolver_type(VALUE t)
     rb_raise(rb_eTypeError, "wrong type argument (Fixnum or String expected)");
     break;
   }
+  RB_GC_GUARD(t);
 }
 
 static VALUE rb_gsl_multiroot_fsolver_new(VALUE klass, VALUE t, VALUE n)

--- a/ext/gsl_native/odeiv.c
+++ b/ext/gsl_native/odeiv.c
@@ -323,7 +323,7 @@ static const gsl_odeiv_step_type* rb_gsl_odeiv_step_type_get(VALUE tt)
 {
   const gsl_odeiv_step_type *T;
   int type;
-  char name[64];
+  char *name;
   switch (TYPE(tt)) {
   case T_FIXNUM:
     type = FIX2INT(tt);
@@ -345,7 +345,7 @@ static const gsl_odeiv_step_type* rb_gsl_odeiv_step_type_get(VALUE tt)
     }
     break;
   case T_STRING:
-    strcpy(name, STR2CSTR(tt));
+    name = STR2CSTR(tt);
     if (str_tail_grep(name, "rk2") == 0) T = gsl_odeiv_step_rk2;
     else if (str_tail_grep(name, "rk4") == 0) T = gsl_odeiv_step_rk4;
     else if (str_tail_grep(name, "rkf45") == 0) T = gsl_odeiv_step_rkf45;
@@ -366,6 +366,7 @@ static const gsl_odeiv_step_type* rb_gsl_odeiv_step_type_get(VALUE tt)
              rb_class2name(CLASS_OF(tt)));
     break;
   }
+  RB_GC_GUARD(tt);
   return T;
 }
 
@@ -440,13 +441,13 @@ static VALUE rb_gsl_odeiv_step_apply(int argc, VALUE *argv, VALUE obj)
 static VALUE rb_gsl_odeiv_step_info(VALUE obj)
 {
   gsl_odeiv_step *s;
-  char buf[256];
+  VALUE buf;
   Data_Get_Struct(obj, gsl_odeiv_step, s);
-  sprintf(buf, "Class:      %s\n", rb_class2name(CLASS_OF(obj)));
-  sprintf(buf, "%sSuperClass: %s\n", buf, rb_class2name(RCLASS_SUPER(CLASS_OF(obj))));
-  sprintf(buf, "%sType:       %s\n", buf, gsl_odeiv_step_name(s));
-  sprintf(buf, "%sDimension:  %d\n", buf, (int) s->dimension);
-  return rb_str_new2(buf);
+  buf = rb_sprintf("Class:      %s\n", rb_class2name(CLASS_OF(obj)));
+  rb_str_catf(buf, "SuperClass: %s\n", rb_class2name(RCLASS_SUPER(CLASS_OF(obj))));
+  rb_str_catf(buf, "Type:       %s\n", gsl_odeiv_step_name(s));
+  rb_str_catf(buf, "Dimension:  %d\n", (int) s->dimension);
+  return buf;
 }
 
 static gsl_odeiv_control* make_control_standard(VALUE epsabs,

--- a/ext/gsl_native/ool.c
+++ b/ext/gsl_native/ool.c
@@ -27,11 +27,11 @@ enum enum_ool_conmin_minimizer_type {
 
 static const ool_conmin_minimizer_type* get_minimizer_type(VALUE t)
 {
-  char name[64];
+  char *name;
 
   switch (TYPE(t)) {
   case T_STRING:
-    strcpy(name, STR2CSTR(t));
+    name = STR2CSTR(t);
     if (str_tail_grep(name, "pgrad") == 0) {
       return ool_conmin_minimizer_pgrad;
     } else if (str_tail_grep(name, "spg") == 0) {
@@ -65,6 +65,7 @@ static const ool_conmin_minimizer_type* get_minimizer_type(VALUE t)
     else rb_raise(rb_eTypeError, "type is given by a String or a Fixnum");
     break;
   }
+  RB_GC_GUARD(t);
 }
 
 static void def_const(VALUE module)

--- a/ext/gsl_native/permutation.c
+++ b/ext/gsl_native/permutation.c
@@ -317,26 +317,20 @@ static VALUE rb_gsl_permutation_print(VALUE obj)
 static VALUE rb_gsl_permutation_to_s(VALUE obj)
 {
   gsl_permutation *v = NULL;
-  char buf[16];
   size_t i;
   VALUE str;
   Data_Get_Struct(obj, gsl_permutation, v);
   str = rb_str_new2("[");
   for (i = 0; i < v->size; i++) {
-    sprintf(buf,  " %d", (int) gsl_permutation_get(v, i));
-    rb_str_cat(str, buf, strlen(buf));
+    rb_str_catf(str, "%d", (int) gsl_permutation_get(v, i));
   }
-  sprintf(buf, " ]");
-  rb_str_cat(str, buf, strlen(buf));
+  rb_str_cat2(str, " ]");
   return str;
 }
 
 static VALUE rb_gsl_permutation_inspect(VALUE obj)
 {
-  VALUE str;
-  char buf[64];
-  sprintf(buf, "%s\n", rb_class2name(CLASS_OF(obj)));
-  str = rb_str_new2(buf);
+  VALUE str = rb_sprintf("%s\n", rb_class2name(CLASS_OF(obj)));
   return rb_str_concat(str, rb_gsl_permutation_to_s(obj));
 }
 

--- a/ext/gsl_native/poly_source.h
+++ b/ext/gsl_native/poly_source.h
@@ -1526,12 +1526,12 @@ static VALUE FUNCTION(rb_gsl_poly,companion_matrix)(VALUE obj)
 static VALUE FUNCTION(rb_gsl_poly,info)(VALUE obj)
 {
   GSL_TYPE(gsl_poly) *v;
-  char buf[256];
+  VALUE buf;
   Data_Get_Struct(obj, GSL_TYPE(gsl_poly), v);
-  sprintf(buf, "Class:      %s\n", rb_class2name(CLASS_OF(obj)));
-  sprintf(buf, "%sSuperClass: %s\n", buf, rb_class2name(RCLASS_SUPER(CLASS_OF(obj))));
-  sprintf(buf, "%sOrder:      %d\n", buf, (int) v->size-1);
-  return rb_str_new2(buf);
+  buf = rb_sprintf("Class:      %s\n", rb_class2name(CLASS_OF(obj)));
+  rb_str_catf(buf, "SuperClass: %s\n", rb_class2name(RCLASS_SUPER(CLASS_OF(obj))));
+  rb_str_catf(buf, "Order:      %d\n", (int) v->size-1);
+  return buf;
 }
 
 #ifdef BASE_DOUBLE

--- a/ext/gsl_native/qrng.c
+++ b/ext/gsl_native/qrng.c
@@ -31,11 +31,11 @@ static const gsl_qrng_type* get_gsl_qrng_type(VALUE t);
 static const gsl_qrng_type* get_gsl_qrng_type(VALUE t)
 {
   const gsl_qrng_type *T;
-  char name[32];
+  char *name;
 
   switch (TYPE(t)) {
   case T_STRING:
-    strcpy(name, STR2CSTR(t));
+    name = STR2CSTR(t);
     if (strstr(name, "niederreiter_2")) return T = gsl_qrng_niederreiter_2;
 #ifdef HAVE_QRNGEXTRA_QRNGEXTRA_H
     else if (strstr(name, "hdsobol")) return T = qrngextra_hdsobol;
@@ -62,6 +62,7 @@ static const gsl_qrng_type* get_gsl_qrng_type(VALUE t)
     rb_raise(rb_eTypeError, "wrong argument type %s (String or Fixnum expected)",
              rb_class2name(CLASS_OF(t)));
   }
+  RB_GC_GUARD(t);
   return T;
 }
 

--- a/ext/gsl_native/root.c
+++ b/ext/gsl_native/root.c
@@ -31,10 +31,10 @@ static VALUE rb_gsl_fsolver_new(VALUE klass, VALUE t)
 {
   gsl_root_fsolver *s = NULL;
   const gsl_root_fsolver_type *T;
-  char name[32];
+  char *name;
   switch (TYPE(t)) {
   case T_STRING:
-    strcpy(name, STR2CSTR(t));
+    name = STR2CSTR(t);
     if (!str_tail_grep(name, "bisection")) {
       T = gsl_root_fsolver_bisection;
     } else if (!str_tail_grep(name, "falsepos")) {
@@ -67,6 +67,7 @@ static VALUE rb_gsl_fsolver_new(VALUE klass, VALUE t)
              rb_class2name(CLASS_OF(t)));
     break;
   }
+  RB_GC_GUARD(t);
   s = gsl_root_fsolver_alloc(T);
   return Data_Wrap_Struct(klass, 0, gsl_root_fsolver_free, s);
 }
@@ -196,10 +197,10 @@ static VALUE rb_gsl_fdfsolver_new(VALUE klass, VALUE t)
 {
   gsl_root_fdfsolver *s = NULL;
   const gsl_root_fdfsolver_type *T;
-  char name[32];
+  char *name;
   switch (TYPE(t)) {
   case T_STRING:
-    strcpy(name, STR2CSTR(t));
+    name = STR2CSTR(t);
     if (!str_tail_grep(name, "newton")) {
       T = gsl_root_fdfsolver_newton;
     } else if (!str_tail_grep(name, "secant")) {
@@ -231,6 +232,7 @@ static VALUE rb_gsl_fdfsolver_new(VALUE klass, VALUE t)
              rb_class2name(CLASS_OF(t)));
     break;
   }
+  RB_GC_GUARD(t);
   s = gsl_root_fdfsolver_alloc(T);
   return Data_Wrap_Struct(klass, 0, gsl_root_fdfsolver_free, s);
 }

--- a/ext/gsl_native/sf.c
+++ b/ext/gsl_native/sf.c
@@ -33,10 +33,7 @@ static VALUE rb_gsl_sf_result_to_s(VALUE obj);
 
 static VALUE rb_gsl_sf_result_inspect(VALUE obj)
 {
-  char buf[64];
-  VALUE str;
-  sprintf(buf, "%s\n", rb_class2name(CLASS_OF(obj)));
-  str = rb_str_new2(buf);
+  VALUE str = rb_sprintf("%s\n", rb_class2name(CLASS_OF(obj)));
   return rb_str_concat(str, rb_gsl_sf_result_to_s(obj));
 }
 
@@ -64,10 +61,8 @@ static VALUE rb_gsl_sf_result_to_a(VALUE obj)
 static VALUE rb_gsl_sf_result_to_s(VALUE obj)
 {
   gsl_sf_result *rslt = NULL;
-  char str[32];
   Data_Get_Struct(obj, gsl_sf_result, rslt);
-  sprintf(str, "%10.9e %10.9e", rslt->val, rslt->err);
-  return rb_str_new2(str);
+  return rb_sprintf("%10.9e %10.9e", rslt->val, rslt->err);
 }
 
 static VALUE rb_gsl_sf_result_e10_new(VALUE klass)
@@ -107,10 +102,8 @@ static VALUE rb_gsl_sf_result_e10_to_a(VALUE obj)
 static VALUE rb_gsl_sf_result_e10_to_s(VALUE obj)
 {
   gsl_sf_result_e10 *rslt = NULL;
-  char str[32];
   Data_Get_Struct(obj, gsl_sf_result_e10, rslt);
-  sprintf(str, "%10.9e %10.9e\n", rslt->val, rslt->err);
-  return rb_str_new2(str);
+  return rb_sprintf("%10.9e %10.9e\n", rslt->val, rslt->err);
 }
 
 VALUE rb_gsl_sf_eval1(double (*func)(double), VALUE argv)

--- a/ext/gsl_native/spline.c
+++ b/ext/gsl_native/spline.c
@@ -342,15 +342,15 @@ static VALUE rb_gsl_spline_eval_integ_e(VALUE obj, VALUE a, VALUE b)
 static VALUE rb_gsl_spline_info(VALUE obj)
 {
   rb_gsl_spline *p = NULL;
-  char buf[256];
+  VALUE buf;
   Data_Get_Struct(obj, rb_gsl_spline, p);
-  sprintf(buf, "Class:      %s\n", rb_class2name(CLASS_OF(obj)));
-  sprintf(buf, "%sSuperClass: %s\n", buf, rb_class2name(RCLASS_SUPER(CLASS_OF(obj))));
-  sprintf(buf, "%sType:       %s\n", buf, gsl_interp_name(p->s->interp));
-  sprintf(buf, "%sxmin:       %f\n", buf, p->s->interp->xmin);
-  sprintf(buf, "%sxmax:       %f\n", buf, p->s->interp->xmax);
-  sprintf(buf, "%sSize:       %d\n", buf, (int) p->s->size);
-  return rb_str_new2(buf);
+  buf = rb_sprintf("Class:      %s\n", rb_class2name(CLASS_OF(obj)));
+  rb_str_catf(buf, "SuperClass: %s\n", rb_class2name(RCLASS_SUPER(CLASS_OF(obj))));
+  rb_str_catf(buf, "Type:       %s\n", gsl_interp_name(p->s->interp));
+  rb_str_catf(buf, "xmin:       %f\n", p->s->interp->xmin);
+  rb_str_catf(buf, "xmax:       %f\n", p->s->interp->xmax);
+  rb_str_catf(buf, "Size:       %d\n", (int) p->s->size);
+  return buf;
 }
 
 static VALUE rb_gsl_spline_name(VALUE obj)

--- a/ext/gsl_native/spline2d.c
+++ b/ext/gsl_native/spline2d.c
@@ -83,9 +83,9 @@ static VALUE rb_gsl_spline2d_accel(VALUE self)
 }
 
 static VALUE rb_gsl_spline2d_evaluate(VALUE self, VALUE xx, VALUE yy,
-  double (*eval)(const gsl_spline2d *, double, double, gsl_interp_accel *, 
+  double (*eval)(const gsl_spline2d *, double, double, gsl_interp_accel *,
     gsl_interp_accel *))
-{ 
+{
   VALUE is_swapped = rb_cvar_get(CLASS_OF(self), rb_intern("@@swapped"));
   VALUE temp;
 
@@ -94,7 +94,7 @@ static VALUE rb_gsl_spline2d_evaluate(VALUE self, VALUE xx, VALUE yy,
     xx = yy;
     yy = temp;
   }
-  
+
   rb_gsl_spline2d *rgs = NULL;
   gsl_vector *vx = NULL, *vy = NULL, *vnew = NULL;
   gsl_matrix *mx = NULL, *my = NULL, *mnew = NULL;
@@ -143,7 +143,7 @@ static VALUE rb_gsl_spline2d_evaluate(VALUE self, VALUE xx, VALUE yy,
       vnew = gsl_vector_alloc(vx->size);
 
       for (i = 0; i < vx->size; i++) {
-        val = (*eval)(rgs->s, gsl_vector_get(vx, i), gsl_vector_get(vy, i), 
+        val = (*eval)(rgs->s, gsl_vector_get(vx, i), gsl_vector_get(vy, i),
           rgs->xacc, rgs->yacc);
         gsl_vector_set(vnew, i, val);
       }
@@ -171,25 +171,25 @@ static VALUE rb_gsl_spline2d_evaluate(VALUE self, VALUE xx, VALUE yy,
 }
 
 static VALUE rb_gsl_spline2d_eval(VALUE self, VALUE xx, VALUE yy)
-{ 
+{
   return rb_gsl_spline2d_evaluate(self, xx, yy, gsl_spline2d_eval);
 }
 
 static VALUE rb_gsl_spline2d_info(VALUE self)
 {
   rb_gsl_spline2d *p = NULL;
-  char buf[256];
+  VALUE buf;
   Data_Get_Struct(self, rb_gsl_spline2d, p);
-  sprintf(buf, "Class:      %s\n", rb_class2name(CLASS_OF(self)));
-  sprintf(buf, "%sSuperClass: %s\n", buf, rb_class2name(RCLASS_SUPER(CLASS_OF(self))));
-  sprintf(buf, "%sType:       %s\n", buf, gsl_interp2d_name(&p->s->interp_object));
-  sprintf(buf, "%sxmin:       %f\n", buf, p->s->interp_object.xmin);
-  sprintf(buf, "%sxmax:       %f\n", buf, p->s->interp_object.xmax);
-  sprintf(buf, "%symin:       %f\n", buf, p->s->interp_object.ymin);
-  sprintf(buf, "%symax:       %f\n", buf, p->s->interp_object.ymax);
-  sprintf(buf, "%sxSize:       %d\n", buf, (int) p->s->interp_object.xsize);
-  sprintf(buf, "%sySize:       %d\n", buf, (int) p->s->interp_object.ysize);
-  return rb_str_new2(buf);
+  buf = rb_sprintf("Class:      %s\n", rb_class2name(CLASS_OF(self)));
+  rb_str_catf(buf, "SuperClass: %s\n", rb_class2name(RCLASS_SUPER(CLASS_OF(self))));
+  rb_str_catf(buf, "Type:       %s\n", gsl_interp2d_name(&p->s->interp_object));
+  rb_str_catf(buf, "xmin:       %f\n", p->s->interp_object.xmin);
+  rb_str_catf(buf, "xmax:       %f\n", p->s->interp_object.xmax);
+  rb_str_catf(buf, "ymin:       %f\n", p->s->interp_object.ymin);
+  rb_str_catf(buf, "ymax:       %f\n", p->s->interp_object.ymax);
+  rb_str_catf(buf, "xSize:       %d\n", (int) p->s->interp_object.xsize);
+  rb_str_catf(buf, "ySize:       %d\n", (int) p->s->interp_object.ysize);
+  return buf;
 }
 
 void Init_gsl_spline2d(VALUE module)

--- a/ext/gsl_native/tensor_source.h
+++ b/ext/gsl_native/tensor_source.h
@@ -766,7 +766,6 @@ static VALUE FUNCTION(rb_tensor,to_s)(VALUE obj)
   QUALIFIED_VIEW(gsl_vector,view) vector;
   GSL_TYPE(gsl_matrix) *m;
   GSL_TYPE(gsl_vector) *v;
-  char buf[16];
   size_t i, j;
   VALUE str;
   Data_Get_Struct(obj, GSL_TYPE(rbgsl_tensor), t);
@@ -782,29 +781,23 @@ static VALUE FUNCTION(rb_tensor,to_s)(VALUE obj)
     m = &(matrix.matrix);
     for (i = 0; i < m->size1; i++) {
       if (i != 0) {
-        strcpy(buf, "  ");
-        rb_str_cat(str, buf, strlen(buf));
+        rb_str_cat2(str, "  ");
       }
       for (j = 0; j < m->size2; j++) {
-        sprintf(buf, PRINTF_FORMAT, FUNCTION(gsl_matrix,get)(m, i, j));
-        rb_str_cat(str, buf, strlen(buf));
+        rb_str_catf(str, PRINTF_FORMAT, FUNCTION(gsl_matrix,get)(m, i, j));
         if (j == SHOW_ELM) {
-          strcpy(buf, "... ");
-          rb_str_cat(str, buf, strlen(buf));
+          rb_str_cat2(str, "... ");
           break;
         }
       }
       if (i == 6) {
-        strcpy(buf, "\n  ... ]");
-        rb_str_cat(str, buf, strlen(buf));
+        rb_str_cat2(str, "\n  ... ]");
         break;
       }
       if (i == m->size1 - 1) {
-        strcpy(buf, "]");
-        rb_str_cat(str, buf, strlen(buf));
+        rb_str_cat2(str, "]");
       } else {
-        strcpy(buf, "\n");
-        rb_str_cat(str, buf, strlen(buf));
+        rb_str_cat2(str, "\n");
       }
     }
     return str;
@@ -816,19 +809,15 @@ static VALUE FUNCTION(rb_tensor,to_s)(VALUE obj)
     vector.vector.owner = 0;
     vector.vector.block = 0;
     v = &(vector.vector);
-    sprintf(buf,  PRINTF_FORMAT, FUNCTION(gsl_vector,get)(v, 0));
-    rb_str_cat(str, buf, strlen(buf));
+    rb_str_catf(str,  PRINTF_FORMAT, FUNCTION(gsl_vector,get)(v, 0));
     for (i = 1; i < v->size; i++) {
-      sprintf(buf,  PRINTF_FORMAT, FUNCTION(gsl_vector,get)(v, i));
-      rb_str_cat(str, buf, strlen(buf));
+      rb_str_catf(str, PRINTF_FORMAT, FUNCTION(gsl_vector,get)(v, i));
       if (i == SHOW_ELM && i != v->size-1) {
-        strcpy(buf, "... ");
-        rb_str_cat(str, buf, strlen(buf));
+        rb_str_cat2(str, "... ");
         break;
       }
     }
-    sprintf(buf, "]");
-    rb_str_cat(str, buf, strlen(buf));
+    rb_str_cat2(str, "]");
     return str;
     break;
   }
@@ -838,10 +827,7 @@ static VALUE FUNCTION(rb_tensor,to_s)(VALUE obj)
 
 static VALUE FUNCTION(rb_tensor,inspect)(VALUE obj)
 {
-  VALUE str;
-  char buf[64];
-  sprintf(buf, "%s\n", rb_class2name(CLASS_OF(obj)));
-  str = rb_str_new2(buf);
+  VALUE str = rb_sprintf("%s\n", rb_class2name(CLASS_OF(obj)));
   return rb_str_concat(str, FUNCTION(rb_tensor,to_s)(obj));
 }
 
@@ -936,14 +922,14 @@ static VALUE FUNCTION(rb_tensor,coerce)(VALUE obj, VALUE other)
 static VALUE FUNCTION(rb_tensor,info)(VALUE obj)
 {
   GSL_TYPE(rbgsl_tensor) *t;
-  char buf[256];
+  VALUE buf;
   Data_Get_Struct(obj, GSL_TYPE(rbgsl_tensor), t);
-  sprintf(buf, "Class:      %s\n", rb_class2name(CLASS_OF(obj)));
-  sprintf(buf, "%sSuperClass: %s\n", buf, rb_class2name(RCLASS_SUPER(CLASS_OF(obj))));
-  sprintf(buf, "%sRank:       %d\n", buf, (int) t->tensor->rank);
-  sprintf(buf, "%sDimension:  %d\n", buf, (int) t->tensor->dimension);
-  sprintf(buf, "%sSize:       %d\n", buf, (int) t->tensor->size);
-  return rb_str_new2(buf);
+  buf = rb_sprintf("Class:      %s\n", rb_class2name(CLASS_OF(obj)));
+  rb_str_catf(buf, "SuperClass: %s\n", rb_class2name(RCLASS_SUPER(CLASS_OF(obj))));
+  rb_str_catf(buf, "Rank:       %d\n", (int) t->tensor->rank);
+  rb_str_catf(buf, "Dimension:  %d\n", (int) t->tensor->dimension);
+  rb_str_catf(buf, "Size:       %d\n", (int) t->tensor->size);
+  return buf;
 }
 
 void FUNCTION(Init_tensor,init)(VALUE module)

--- a/ext/gsl_native/vector_complex.c
+++ b/ext/gsl_native/vector_complex.c
@@ -414,7 +414,6 @@ static VALUE rb_gsl_vector_complex_set_basis(VALUE obj, VALUE ii)
 static VALUE rb_gsl_vector_complex_to_s(VALUE obj)
 {
   gsl_vector_complex *v = NULL;
-  char buf[64];
   size_t i;
   VALUE str;
   gsl_complex * z;
@@ -425,44 +424,42 @@ static VALUE rb_gsl_vector_complex_to_s(VALUE obj)
   if (VECTOR_COMPLEX_COL_P(obj)) {
     for (i = 0; i < v->size; i++) {
       if (i != 0) {
-        rb_str_cat(str, "  ", 2);
+        rb_str_cat2(str, "  ");
       }
       z = GSL_COMPLEX_AT(v, i);
-      sprintf(buf, "[%4.3e %4.3e]", GSL_REAL(*z), GSL_IMAG(*z));
-      if (i != v->size-1) strcat(buf, "\n");
-      rb_str_cat(str, buf, strlen(buf));
+      rb_str_catf(str, "[%4.3e %4.3e]", GSL_REAL(*z), GSL_IMAG(*z));
+      if (i != v->size-1) rb_str_cat2(str, "\n");
       if (i >= 10 && i != v->size-1) {
-        rb_str_cat(str, "  ...", 5);
+        rb_str_cat2(str, "  ...");
         break;
       }
     }
   } else {
     z = GSL_COMPLEX_AT(v, 0);
-    sprintf(buf, "[%4.3e %4.3e]", GSL_REAL(*z), GSL_IMAG(*z));
-    rb_str_cat(str, buf, strlen(buf));
+    rb_str_catf(str, "[%4.3e %4.3e]", GSL_REAL(*z), GSL_IMAG(*z));
     for (i = 1; i < v->size; i++) {
       z = GSL_COMPLEX_AT(v, i);
-      sprintf(buf, " [%4.3e %4.3e]", GSL_REAL(*z), GSL_IMAG(*z));
-      rb_str_cat(str, buf, strlen(buf));
+      rb_str_catf(str, " [%4.3e %4.3e]", GSL_REAL(*z), GSL_IMAG(*z));
       if (i >= 10 && i != v->size-1) {
-        rb_str_cat(str, " ...", 4);
+        rb_str_cat2(str, " ...");
         break;
       }
     }
   }
-  rb_str_cat(str, " ]", 2);
+  rb_str_cat2(str, " ]");
   return str;
 }
 
 static VALUE rb_gsl_vector_complex_inspect(VALUE obj)
 {
   VALUE str;
-  char buf[128];
   gsl_vector_complex *v;
 
   Data_Get_Struct(obj, gsl_vector_complex, v);
-  sprintf(buf, "#<%s[%lu]:%#lx>\n", rb_class2name(CLASS_OF(obj)), v->size, NUM2ULONG(rb_obj_id(obj)));
-  str = rb_str_new2(buf);
+  str = rb_sprintf("#<%s[%lu]:%#lx>\n",
+                   rb_class2name(CLASS_OF(obj)),
+                   v->size,
+                   NUM2ULONG(rb_obj_id(obj)));
   return rb_str_concat(str, rb_gsl_vector_complex_to_s(obj));
 }
 
@@ -2238,4 +2235,3 @@ void Init_gsl_vector_complex(VALUE module)
   rb_define_method(cgsl_vector_complex, "not_equal?", rb_gsl_vector_complex_not_equal, -1);
   rb_define_alias(cgsl_vector_complex, "!=", "not_equal?");
 }
-

--- a/ext/gsl_native/vector_source.h
+++ b/ext/gsl_native/vector_source.h
@@ -1288,7 +1288,7 @@ VALUE FUNCTION(rb_gsl_vector,print)(VALUE obj)
 VALUE FUNCTION(rb_gsl_vector,to_s)(VALUE obj)
 {
   GSL_TYPE(gsl_vector) *v = NULL;
-  char buf[32], format[32], format2[32];
+  char format[32], format2[32];
   size_t i;
   VALUE str;
   BASE x;
@@ -1317,45 +1317,35 @@ VALUE FUNCTION(rb_gsl_vector,to_s)(VALUE obj)
 #endif
     for (i = 0; i < v->size; i++) {
       if (i != 0) {
-        strcpy(buf, "  ");
-        rb_str_cat(str, buf, strlen(buf));
+        rb_str_cat2(str, "  ");
       }
       x = FUNCTION(gsl_vector,get)(v, i);
-      if (x < 0) sprintf(buf, format, x);
-      else sprintf(buf, format2, x);
-      if (i != v->size-1) strcat(buf, "\n");
-      rb_str_cat(str, buf, strlen(buf));
+      if (x < 0) rb_str_catf(str, format, x);
+      else rb_str_catf(str, format2, x);
+      if (i != v->size-1) rb_str_cat2(str, "\n");
       if (i >= 20 && i != v->size-1) {
-        strcpy(buf, "  ...");
-        rb_str_cat(str, buf, strlen(buf));
+        rb_str_cat2(str, "  ...");
         break;
       }
     }
   } else {
-    sprintf(buf,  PRINTF_FORMAT, FUNCTION(gsl_vector,get)(v, 0));
-    rb_str_cat(str, buf, strlen(buf));
+    rb_str_catf(str, PRINTF_FORMAT, FUNCTION(gsl_vector,get)(v, 0));
     for (i = 1; i < v->size; i++) {
-      sprintf(buf,  PRINTF_FORMAT, FUNCTION(gsl_vector,get)(v, i));
-      rb_str_cat(str, buf, strlen(buf));
+      rb_str_catf(str,  PRINTF_FORMAT, FUNCTION(gsl_vector,get)(v, i));
       if ((int) i >= (55/dig) && i != v->size-1) {
-        strcpy(buf, "... ");
-        rb_str_cat(str, buf, strlen(buf));
+        rb_str_cat2(str, "... ");
         break;
       }
     }
   }
-  sprintf(buf, "]");
-  rb_str_cat(str, buf, strlen(buf));
+  rb_str_cat2(str, "]");
   return str;
 }
 #undef SHOW_ELM
 
 static VALUE FUNCTION(rb_gsl_vector,inspect)(VALUE obj)
 {
-  VALUE str;
-  char buf[64];
-  sprintf(buf, "%s\n", rb_class2name(CLASS_OF(obj)));
-  str = rb_str_new2(buf);
+  VALUE str = rb_sprintf("%s\n", rb_class2name(CLASS_OF(obj)));
   return rb_str_concat(str, FUNCTION(rb_gsl_vector,to_s)(obj));
 }
 
@@ -1587,7 +1577,6 @@ static VALUE FUNCTION(rb_gsl_vector,to_tensor)(int argc, VALUE *argv, VALUE obj)
 #endif
 static VALUE FUNCTION(rb_gsl_vector,to_gplot)(int argc, VALUE *argv, VALUE obj)
 {
-  char buf[1024] = "";
   size_t i, j, len = 0, nv, istart;
   VALUE str, tmp;
   GSL_TYPE(gsl_vector) *v, **vp;
@@ -1619,15 +1608,14 @@ static VALUE FUNCTION(rb_gsl_vector,to_gplot)(int argc, VALUE *argv, VALUE obj)
       rb_raise(rb_eRuntimeError, "vectors must have equal lengths");
     vp[i+istart] = v;
   }
-  str = rb_str_new2(buf);
+  str = rb_str_new2("");
   for (j = 0; j < len; j++) {
     for (i = 0; i < nv; i++) {
-      sprintf(buf, PRINTF_FORMAT2, FUNCTION(gsl_vector,get)(vp[i], j));
-      rb_str_buf_cat(str, buf, strlen(buf));
+      rb_str_catf(str, PRINTF_FORMAT2, FUNCTION(gsl_vector,get)(vp[i], j));
     }
-    rb_str_buf_cat2(str, "\n");
+    rb_str_cat2(str, "\n");
   }
-  rb_str_buf_cat2(str, "\n");
+  rb_str_cat2(str, "\n");
   free((GSL_TYPE(gsl_vector)**)vp);
   return str;
 }
@@ -2894,7 +2882,7 @@ static VALUE FUNCTION(rb_gsl_vector,join)(int argc, VALUE *argv, VALUE obj)
 {
   GSL_TYPE(gsl_vector) *v;
   VALUE str, sep;
-  char *p, buf[16];
+  char *p;
   size_t i;
   switch (argc) {
   case 0:
@@ -2912,11 +2900,10 @@ static VALUE FUNCTION(rb_gsl_vector,join)(int argc, VALUE *argv, VALUE obj)
   str = rb_str_new2(p);
   for (i = 0; i < v->size; i++) {
 #ifdef BASE_DOUBLE
-    sprintf(buf, "%4.3e", FUNCTION(gsl_vector,get)(v, i));
+    rb_str_catf(str, "%4.3e", FUNCTION(gsl_vector,get)(v, i));
 #else
-    sprintf(buf, "%d", FUNCTION(gsl_vector,get)(v, i));
+    rb_str_catf(str, "%d", FUNCTION(gsl_vector,get)(v, i));
 #endif
-    rb_str_concat(str, rb_str_new2(buf));
     if (i != v->size-1) rb_str_concat(str, sep);
   }
   return str;


### PR DESCRIPTION
While working on my previous PR  (#48) I ran into issues with string handling that would cause ruby to crash with a segfault. This PR aims to fix most (but not all) of those problems.

* Refactor most of string handling code to use rb_str_* functions. This fixes numerous instances of unsafe string handling using strcpy/sprintf that could lead to buffer overflows and simplifies code in other places.
* Don't copy ruby strings to stack buffers when not needed, just use STR2CSTR (requires RB_GC_GUARD). This fixes possible stack buffer overflows.
* Change definition of STR2CSTR to StringValueCStr, as StringValuePtr does not even guarantee returning a null-terminated string.

Things that are not fixed:
 * rb_gsl_complex_printf (will do another PR, because I don't see an obvious way to fix it without possibly breaking compatibility)
 * any function that calls popen (I find these very suspect and would need more time to think them through).