### PR TITLE
Saner behavior in rb_gsl_complex_printf.

### DIFF
--- a/ext/gsl_native/complex.c
+++ b/ext/gsl_native/complex.c
@@ -166,12 +166,16 @@ static VALUE rb_gsl_complex_print(VALUE obj)
 static VALUE rb_gsl_complex_printf(VALUE obj, VALUE s)
 {
   gsl_complex *c = NULL;
-  char tmp[32], format[64];
+  VALUE format, out;
+  VALUE vals[2];
   Check_Type(s, T_STRING);
   Data_Get_Struct(obj, gsl_complex, c);
-  strcpy(tmp, STR2CSTR(s));
-  sprintf(format, "%s %s\n", tmp, tmp);
-  fprintf(stdout, format, GSL_REAL(*c), GSL_IMAG(*c));
+
+  vals[0] = rb_float_new(GSL_REAL(*c));
+  vals[1] = rb_float_new(GSL_IMAG(*c));
+  format = rb_sprintf("%"PRIsVALUE" %"PRIsVALUE"\n", s, s);
+  out = rb_str_format(2, vals, format);
+  fwrite(StringValuePtr(out), 1, RSTRING_LEN(out), stdout);
   return obj;
 }
 


### PR DESCRIPTION
Use Ruby string formatting instead of sprintf in rb_gsl_complex_printf.
This changes the behavior in some ways:
 * the function will no longer print/leak garbage from the stack if it is given a format string with too many directives. It will raise an ArgumentError instead.
 * the function can no longer crash ruby by overflowing the stack with a long format string
 * the availability and behavior of directives will match ruby sprintf and not given system's libc
 * saner type conversion rules will be used (e.g. "%d" will actually print out the integer parts of the complex number instead of reinterpreting the bits of the float as an integer)

IMHO these are desirable changes, but they do break backwards compatibility.