### PR TITLE
Ruby 3 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,15 @@ rvm:
   - 2.2.6
   - 2.3.3
   - 2.4.0
+  - 2.5
+  - 2.6
+  - 2.7
+  - 3.0.0
 
 before_install:
   - sudo apt-get update -qq
   - sudo apt-get install -y libgsl0-dev
-  - gem update bundler
-  - bundle install
+  - gem install bundler:1.17.3
+  - bundle _1.17.3_ install
   - bundle exec rake compile
   - bundle exec rake test

--- a/ext/gsl_native/extconf.rb
+++ b/ext/gsl_native/extconf.rb
@@ -21,6 +21,7 @@ def create_conf_h(file) #:nodoc:
 
     # FIXME: Find a better way to do this:
     hfile.puts "#define RUBY_2 1" if RUBY_VERSION >= '2.0'
+    hfile.puts "#define RUBY_3 1" if RUBY_VERSION >= '3.0'
 
     for line in $defs
       line =~ /^-D(.*)/

--- a/ext/gsl_native/gsl_narray.c
+++ b/ext/gsl_native/gsl_narray.c
@@ -570,7 +570,7 @@ gsl_matrix_int_view* na_to_gm_int_view(VALUE nna)
 }
 
 #include <gsl/gsl_histogram.h>
-EXTERN VALUE cgsl_histogram;
+extern VALUE cgsl_histogram;
 static VALUE rb_gsl_narray_histogram(int argc, VALUE *argv, VALUE obj)
 {
   double *ptr, *ptr_range;

--- a/ext/gsl_native/include/rb_gsl.h
+++ b/ext/gsl_native/include/rb_gsl.h
@@ -109,7 +109,7 @@ void Init_tensor_int_init(VALUE module);
 
 void Init_gsl_dirac(VALUE module);
 
-EXTERN VALUE cGSL_Object;
+extern VALUE cGSL_Object;
 
 void Init_tamu_anova(VALUE module);
 

--- a/ext/gsl_native/include/rb_gsl_array.h
+++ b/ext/gsl_native/include/rb_gsl_array.h
@@ -29,41 +29,41 @@
 typedef gsl_permutation gsl_index;
 
 #ifdef HAVE_NARRAY_H
-EXTERN VALUE cNArray;
+extern VALUE cNArray;
 #endif
 
 #ifdef HAVE_NMATRIX_H
-EXTERN VALUE cNMatrix;
+extern VALUE cNMatrix;
 #endif
 
-EXTERN VALUE cgsl_block, cgsl_block_int;
-EXTERN VALUE cgsl_block_uchar;
-EXTERN VALUE cgsl_block_complex;
-EXTERN VALUE cgsl_vector, cgsl_vector_complex;
-EXTERN VALUE cgsl_vector_col;
-EXTERN VALUE cgsl_vector_col_view;
-EXTERN VALUE cgsl_vector_complex_col;
-EXTERN VALUE cgsl_vector_complex_col_view;
-EXTERN VALUE cgsl_vector_view, cgsl_vector_complex_view;
-EXTERN VALUE cgsl_vector_view_ro, cgsl_vector_col_view_ro;
-EXTERN VALUE cgsl_vector_complex_view_ro;
+extern VALUE cgsl_block, cgsl_block_int;
+extern VALUE cgsl_block_uchar;
+extern VALUE cgsl_block_complex;
+extern VALUE cgsl_vector, cgsl_vector_complex;
+extern VALUE cgsl_vector_col;
+extern VALUE cgsl_vector_col_view;
+extern VALUE cgsl_vector_complex_col;
+extern VALUE cgsl_vector_complex_col_view;
+extern VALUE cgsl_vector_view, cgsl_vector_complex_view;
+extern VALUE cgsl_vector_view_ro, cgsl_vector_col_view_ro;
+extern VALUE cgsl_vector_complex_view_ro;
 
-EXTERN VALUE cgsl_vector_int, cgsl_vector_int_col;
-EXTERN VALUE cgsl_vector_int_view, cgsl_vector_int_col_view;
-EXTERN VALUE cgsl_vector_int_view_ro, cgsl_vector_int_col_view_ro;
+extern VALUE cgsl_vector_int, cgsl_vector_int_col;
+extern VALUE cgsl_vector_int_view, cgsl_vector_int_col_view;
+extern VALUE cgsl_vector_int_view_ro, cgsl_vector_int_col_view_ro;
 
-EXTERN VALUE cgsl_matrix, cgsl_matrix_complex;
-EXTERN VALUE cgsl_matrix_view_ro;
-EXTERN VALUE cgsl_matrix_complex_view_ro;
-EXTERN VALUE cgsl_matrix_view, cgsl_matrix_complex_view;
-EXTERN VALUE cgsl_matrix_int, cgsl_matrix_int_view;
-EXTERN VALUE cgsl_matrix_int_view_ro;
-EXTERN VALUE cgsl_permutation;
-EXTERN VALUE cgsl_index;
-EXTERN VALUE cgsl_function;
-EXTERN VALUE mgsl_narray;
+extern VALUE cgsl_matrix, cgsl_matrix_complex;
+extern VALUE cgsl_matrix_view_ro;
+extern VALUE cgsl_matrix_complex_view_ro;
+extern VALUE cgsl_matrix_view, cgsl_matrix_complex_view;
+extern VALUE cgsl_matrix_int, cgsl_matrix_int_view;
+extern VALUE cgsl_matrix_int_view_ro;
+extern VALUE cgsl_permutation;
+extern VALUE cgsl_index;
+extern VALUE cgsl_function;
+extern VALUE mgsl_narray;
 
-EXTERN VALUE mDirac;
+extern VALUE mDirac;
 
 gsl_matrix_view* gsl_matrix_view_alloc();
 void gsl_matrix_view_free(gsl_matrix_view * mv);

--- a/ext/gsl_native/include/rb_gsl_common.h
+++ b/ext/gsl_native/include/rb_gsl_common.h
@@ -25,8 +25,9 @@
 #include <gsl/gsl_ieee_utils.h>
 #include "rb_gsl_with_narray.h"
 #include "rb_gsl_with_nmatrix.h"
+#include "gsl_config.h"
 
-EXTERN ID rb_gsl_id_beg, rb_gsl_id_end, rb_gsl_id_excl, rb_gsl_id_to_a;
+extern ID rb_gsl_id_beg, rb_gsl_id_end, rb_gsl_id_excl, rb_gsl_id_to_a;
 
 #ifndef CHECK_FIXNUM
 #define CHECK_FIXNUM(x) if(!FIXNUM_P(x)) rb_raise(rb_eTypeError,"Fixnum expected");
@@ -292,7 +293,9 @@ EXTERN ID rb_gsl_id_beg, rb_gsl_id_end, rb_gsl_id_excl, rb_gsl_id_to_a;
 #endif
 
 #ifndef RBGSL_SET_CLASS
-#ifdef RB_OBJ_WRITE
+#if defined(RUBY_3)
+#define RBGSL_SET_CLASS0(obj0, cls) RB_OBJ_WRITE(obj0, &(RBASIC(obj0)->klass), cls)
+#elif defined(RB_OBJ_WRITE)
 #define RBGSL_SET_CLASS0(obj0, cls) RB_OBJ_WRITE(obj0, &(RBASIC_CLASS(obj0)), cls)
 #else
 #define RBGSL_SET_CLASS0(obj0, cls) RBASIC(obj0)->klass = cls
@@ -349,5 +352,5 @@ VALUE rb_gsl_nary_eval1(VALUE ary, double (*f)(double));
 VALUE rb_gsl_nmatrix_eval1(VALUE ary, double (*f)(double));
 #endif
 
-EXTERN VALUE cGSL_Object;
+extern VALUE cGSL_Object;
 #endif

--- a/ext/gsl_native/include/rb_gsl_complex.h
+++ b/ext/gsl_native/include/rb_gsl_complex.h
@@ -18,7 +18,7 @@
 #include <gsl/gsl_complex.h>
 #include <gsl/gsl_complex_math.h>
 
-EXTERN VALUE cgsl_complex;
+extern VALUE cgsl_complex;
 VALUE rb_gsl_complex_pow(int argc, VALUE *argv, VALUE obj);
 VALUE rb_gsl_complex_pow_real(int argc, VALUE *argv, VALUE obj);
 

--- a/ext/gsl_native/include/rb_gsl_const.h
+++ b/ext/gsl_native/include/rb_gsl_const.h
@@ -18,6 +18,6 @@
 #include <gsl/gsl_const_cgsm.h>
 #include <gsl/gsl_const_num.h>
 
-EXTERN VALUE mgsl_const_mks, mgsl_const_cgs;
+extern VALUE mgsl_const_mks, mgsl_const_cgs;
 
 #endif

--- a/ext/gsl_native/include/rb_gsl_fft.h
+++ b/ext/gsl_native/include/rb_gsl_fft.h
@@ -39,11 +39,11 @@ enum {
   RB_GSL_FFT_COPY,
 };
 
-EXTERN VALUE mgsl_fft;
-EXTERN VALUE cgsl_fft_wavetable;
-EXTERN VALUE cgsl_fft_wavetable_factor;
-EXTERN VALUE cgsl_fft_complex_wavetable, cgsl_fft_complex_workspace;
-EXTERN VALUE cgsl_fft_real_wavetable, cgsl_fft_halfcomplex_wavetable;
-EXTERN VALUE cgsl_fft_real_workspace;
+extern VALUE mgsl_fft;
+extern VALUE cgsl_fft_wavetable;
+extern VALUE cgsl_fft_wavetable_factor;
+extern VALUE cgsl_fft_complex_wavetable, cgsl_fft_complex_workspace;
+extern VALUE cgsl_fft_real_wavetable, cgsl_fft_halfcomplex_wavetable;
+extern VALUE cgsl_fft_real_workspace;
 
 #endif

--- a/ext/gsl_native/include/rb_gsl_fit.h
+++ b/ext/gsl_native/include/rb_gsl_fit.h
@@ -18,6 +18,6 @@
 #include <gsl/gsl_multifit_nlin.h>
 #include "rb_gsl_array.h"
 
-EXTERN VALUE mgsl_multifit;
+extern VALUE mgsl_multifit;
 
 #endif

--- a/ext/gsl_native/include/rb_gsl_function.h
+++ b/ext/gsl_native/include/rb_gsl_function.h
@@ -15,8 +15,8 @@
 
 #include "rb_gsl.h"
 
-EXTERN VALUE cgsl_function;
-EXTERN VALUE cgsl_function_fdf;
+extern VALUE cgsl_function;
+extern VALUE cgsl_function_fdf;
 extern ID RBGSL_ID_call, RBGSL_ID_arity;
 void gsl_function_mark(gsl_function *f);
 void gsl_function_free(gsl_function *f);

--- a/ext/gsl_native/include/rb_gsl_histogram.h
+++ b/ext/gsl_native/include/rb_gsl_histogram.h
@@ -18,11 +18,11 @@
 #include <gsl/gsl_histogram2d.h>
 #include "rb_gsl.h"
 
-EXTERN VALUE cgsl_histogram;
-EXTERN VALUE cgsl_histogram_range;
-EXTERN VALUE cgsl_histogram_bin;
-EXTERN VALUE cgsl_histogram2d;
-EXTERN VALUE cgsl_histogram2d_view;
+extern VALUE cgsl_histogram;
+extern VALUE cgsl_histogram_range;
+extern VALUE cgsl_histogram_bin;
+extern VALUE cgsl_histogram2d;
+extern VALUE cgsl_histogram2d_view;
 
 typedef struct {
   gsl_histogram h;

--- a/ext/gsl_native/include/rb_gsl_poly.h
+++ b/ext/gsl_native/include/rb_gsl_poly.h
@@ -17,12 +17,12 @@
 #include "rb_gsl_complex.h"
 #include "rb_gsl_array.h"
 
-EXTERN VALUE cgsl_poly;
-EXTERN VALUE cgsl_poly_int;
-EXTERN VALUE cgsl_poly_dd;
-EXTERN VALUE cgsl_poly_taylor;
-EXTERN VALUE cgsl_poly_workspace;
-EXTERN VALUE cgsl_rational;
+extern VALUE cgsl_poly;
+extern VALUE cgsl_poly_int;
+extern VALUE cgsl_poly_dd;
+extern VALUE cgsl_poly_taylor;
+extern VALUE cgsl_poly_workspace;
+extern VALUE cgsl_rational;
 
 typedef gsl_vector gsl_poly;
 typedef gsl_vector_int gsl_poly_int;

--- a/ext/gsl_native/include/rb_gsl_rng.h
+++ b/ext/gsl_native/include/rb_gsl_rng.h
@@ -15,6 +15,6 @@
 #include <gsl/gsl_rng.h>
 #include "rb_gsl.h"
 
-EXTERN VALUE cgsl_rng;
+extern VALUE cgsl_rng;
 
 #endif

--- a/ext/gsl_native/include/rb_gsl_root.h
+++ b/ext/gsl_native/include/rb_gsl_root.h
@@ -16,7 +16,7 @@
 #include <gsl/gsl_roots.h>
 #include "rb_gsl.h"
 
-EXTERN VALUE cgsl_fsolver;
-EXTERN VALUE cgsl_fdfsolver;
+extern VALUE cgsl_fsolver;
+extern VALUE cgsl_fdfsolver;
 
 #endif

--- a/ext/gsl_native/include/rb_gsl_sf.h
+++ b/ext/gsl_native/include/rb_gsl_sf.h
@@ -16,7 +16,7 @@
 #include <gsl/gsl_sf_mathieu.h>
 #include "rb_gsl.h"
 
-EXTERN VALUE cgsl_sf_result, cgsl_sf_result_e10;
+extern VALUE cgsl_sf_result, cgsl_sf_result_e10;
 
 VALUE rb_gsl_sf_result_new(VALUE klass);
 

--- a/ext/gsl_native/include/rb_gsl_tensor.h
+++ b/ext/gsl_native/include/rb_gsl_tensor.h
@@ -5,7 +5,7 @@
 #include "rb_gsl.h"
 #include <tensor/tensor.h>
 
-EXTERN VALUE cgsl_tensor, cgsl_tensor_int;
+extern VALUE cgsl_tensor, cgsl_tensor_int;
 
 enum {
   TENSOR_ADD,

--- a/ext/gsl_native/include/templates_off.h
+++ b/ext/gsl_native/include/templates_off.h
@@ -85,3 +85,8 @@
 #undef NAME
 #undef STRING
 #undef EXPAND
+
+#ifdef RUBY_3
+#undef memcpy
+#define memcpy ruby_nonempty_memcpy
+#endif

--- a/ext/gsl_native/include/templates_on.h
+++ b/ext/gsl_native/include/templates_on.h
@@ -239,3 +239,9 @@
 #define STRING(x) #x
 #define EXPAND(x) STRING(x)
 #define NAME(x) EXPAND(GSL_TYPE(x))
+
+// Ruby 3 redefines memcpy as ruby_nonempty_memcpy, breaking everything if memcpy is used in preprocessor
+#ifdef RUBY_3
+#undef memcpy
+#define memcpy memcpy
+#endif

--- a/ext/gsl_native/interp.c
+++ b/ext/gsl_native/interp.c
@@ -12,7 +12,7 @@
 #include "include/rb_gsl_interp.h"
 
 VALUE cgsl_interp_accel; /* this is used also in spline.c */
-EXTERN VALUE cgsl_vector, cgsl_matrix;
+extern VALUE cgsl_vector, cgsl_matrix;
 
 static void rb_gsl_interp_free(rb_gsl_interp *sp);
 

--- a/ext/gsl_native/interp2d.c
+++ b/ext/gsl_native/interp2d.c
@@ -12,7 +12,7 @@
 #include "include/rb_gsl_interp2d.h"
 
 VALUE cgsl_interp2d_accel; /* this is used also in spline2d.c */
-EXTERN VALUE cgsl_vector, cgsl_matrix;
+extern VALUE cgsl_vector, cgsl_matrix;
 
 static VALUE rb_gsl_interp2d_alloc(int argc, VALUE *argv, VALUE self)
 { 

--- a/ext/gsl_native/linalg_complex.c
+++ b/ext/gsl_native/linalg_complex.c
@@ -14,8 +14,8 @@
 #include "include/rb_gsl_common.h"
 #include "include/rb_gsl_linalg.h"
 
-EXTERN VALUE mgsl_linalg;
-EXTERN VALUE cgsl_complex;
+extern VALUE mgsl_linalg;
+extern VALUE cgsl_complex;
 
 static VALUE cgsl_matrix_complex_LU;
 static VALUE cgsl_matrix_complex_C;

--- a/ext/gsl_native/matrix_source.h
+++ b/ext/gsl_native/matrix_source.h
@@ -47,6 +47,11 @@
 #define VEC_VIEW_P VECTOR_INT_VIEW_P
 #endif
 
+// Ruby 3 redefines memcpy as ruby_nonempty_memcpy, breaking everything if memcpy is used in preprocessor
+#ifdef RUBY_3
+#define memcpy memcpy
+#endif
+
 // From ext/vector_source.c
 void FUNCTION(get_range,beg_en_n)(VALUE range, BASE *beg, BASE *en, size_t *n, int *step);
 
@@ -1536,7 +1541,7 @@ static int FUNCTION(mygsl_matrix,equal)(GSL_TYPE(gsl_matrix) *a, GSL_TYPE(gsl_ma
 }
 
 #ifdef HAVE_TENSOR_TENSOR_H
-EXTERN VALUE cgsl_tensor, cgsl_tensor_int;
+extern VALUE cgsl_tensor, cgsl_tensor_int;
 VALUE rb_gsl_tensor_equal(int argc, VALUE *argv, VALUE obj);
 VALUE rb_gsl_tensor_int_equal(int argc, VALUE *argv, VALUE obj);
 #ifdef BASE_DOUBLE
@@ -2706,3 +2711,7 @@ void FUNCTION(Init_gsl_matrix,init)(VALUE module)
 #undef MAT_ROW_P
 #undef CHECK_MAT
 #undef MAT_VIEW_P
+
+#ifdef RUBY_3
+#define memcpy ruby_nonempty_memcpy
+#endif

--- a/ext/gsl_native/matrix_source.h
+++ b/ext/gsl_native/matrix_source.h
@@ -47,11 +47,6 @@
 #define VEC_VIEW_P VECTOR_INT_VIEW_P
 #endif
 
-// Ruby 3 redefines memcpy as ruby_nonempty_memcpy, breaking everything if memcpy is used in preprocessor
-#ifdef RUBY_3
-#define memcpy memcpy
-#endif
-
 // From ext/vector_source.c
 void FUNCTION(get_range,beg_en_n)(VALUE range, BASE *beg, BASE *en, size_t *n, int *step);
 
@@ -2711,7 +2706,3 @@ void FUNCTION(Init_gsl_matrix,init)(VALUE module)
 #undef MAT_ROW_P
 #undef CHECK_MAT
 #undef MAT_VIEW_P
-
-#ifdef RUBY_3
-#define memcpy ruby_nonempty_memcpy
-#endif

--- a/ext/gsl_native/monte.c
+++ b/ext/gsl_native/monte.c
@@ -25,7 +25,7 @@ static VALUE cgsl_monte_miser;
 static VALUE cgsl_monte_vegas;
 static VALUE cgsl_monte_function;
 static VALUE cgsl_monte_miser_params, cgsl_monte_vegas_params;
-EXTERN VALUE cgsl_vector;
+extern VALUE cgsl_vector;
 
 enum {
   GSL_MONTE_PLAIN_STATE = 1,

--- a/ext/gsl_native/root.c
+++ b/ext/gsl_native/root.c
@@ -14,7 +14,7 @@
 #include "include/rb_gsl_function.h"
 #include "include/rb_gsl_root.h"
 
-EXTERN VALUE cgsl_function_fdf;
+extern VALUE cgsl_function_fdf;
 
 enum {
   GSL_ROOT_FSOLVER_BISECTION,

--- a/ext/gsl_native/sf_bessel.c
+++ b/ext/gsl_native/sf_bessel.c
@@ -11,7 +11,7 @@
 */
 
 #include "include/rb_gsl_sf.h"
-EXTERN VALUE cgsl_vector;
+extern VALUE cgsl_vector;
 
 /* Cylindrical Bessel Functions */
 static VALUE rb_gsl_sf_bessel_J0(VALUE obj, VALUE x)

--- a/ext/gsl_native/sf_coulomb.c
+++ b/ext/gsl_native/sf_coulomb.c
@@ -11,7 +11,7 @@
 */
 
 #include "include/rb_gsl_sf.h"
-EXTERN VALUE cgsl_vector;
+extern VALUE cgsl_vector;
 
 static VALUE rb_gsl_sf_hydrogenicR_1(VALUE obj, VALUE Z, VALUE r)
 {

--- a/ext/gsl_native/sf_legendre.c
+++ b/ext/gsl_native/sf_legendre.c
@@ -10,7 +10,7 @@
 */
 
 #include "include/rb_gsl_sf.h"
-EXTERN VALUE cgsl_vector;
+extern VALUE cgsl_vector;
 
 static VALUE rb_gsl_sf_legendre_P1(VALUE obj, VALUE x)
 {

--- a/ext/gsl_native/sort.c
+++ b/ext/gsl_native/sort.c
@@ -13,8 +13,8 @@
 #include <gsl/gsl_heapsort.h>
 #include <gsl/gsl_sort.h>
 
-EXTERN ID RBGSL_ID_call;
-EXTERN VALUE cgsl_complex;
+extern ID RBGSL_ID_call;
+extern VALUE cgsl_complex;
 
 int rb_gsl_comparison_double(const void *aa, const void *bb);
 int rb_gsl_comparison_complex(const void *aa, const void *bb);

--- a/ext/gsl_native/spline.c
+++ b/ext/gsl_native/spline.c
@@ -11,7 +11,7 @@
 
 #include "include/rb_gsl_interp.h"
 
-EXTERN VALUE cgsl_interp_accel;  /* defined in interp.c */
+extern VALUE cgsl_interp_accel;  /* defined in interp.c */
 
 static void rb_gsl_spline_free(rb_gsl_spline *sp);
 

--- a/ext/gsl_native/spline2d.c
+++ b/ext/gsl_native/spline2d.c
@@ -11,7 +11,7 @@
 #ifdef GSL_2_0_LATER
 #include "include/rb_gsl_interp2d.h"
 
-EXTERN VALUE cgsl_interp2d_accel;  /* defined in interp2d.c */
+extern VALUE cgsl_interp2d_accel;  /* defined in interp2d.c */
 static void rb_gsl_spline2d_free(rb_gsl_spline2d *fr);
 
 static VALUE rb_gsl_spline2d_alloc(int argc, VALUE *argv, VALUE self)

--- a/ext/gsl_native/vector_complex.c
+++ b/ext/gsl_native/vector_complex.c
@@ -12,7 +12,7 @@
 #include "include/rb_gsl_array.h"
 #include "include/rb_gsl_complex.h"
 
-EXTERN VALUE cgsl_complex;
+extern VALUE cgsl_complex;
 static VALUE rb_gsl_vector_complex_inner_product(int argc, VALUE *argv, VALUE obj);
 static VALUE rb_gsl_vector_complex_product_to_m(int argc, VALUE *argv, VALUE obj);
 

--- a/ext/gsl_native/vector_source.h
+++ b/ext/gsl_native/vector_source.h
@@ -36,6 +36,11 @@
 #define VEC_VIEW_P VECTOR_INT_VIEW_P
 #endif
 
+// Ruby 3 redefines memcpy as ruby_nonempty_memcpy, breaking everything if memcpy is used in preprocessor
+#ifdef RUBY_3
+#define memcpy memcpy
+#endif
+
 void FUNCTION(get_range,beg_en_n)(VALUE range, BASE *beg, BASE *en, size_t *n, int *step);
 
 void get_range_beg_en_n_for_size(VALUE range,
@@ -687,7 +692,7 @@ static VALUE FUNCTION(rb_gsl_vector,uplus)(VALUE obj)
   return obj;
 }
 
-EXTERN VALUE cgsl_poly;
+extern VALUE cgsl_poly;
 
 VALUE FUNCTION(rb_gsl_vector,uminus)(VALUE obj)
 {
@@ -1009,7 +1014,7 @@ int FUNCTION(rbgsl_vector,equal)(const GSL_TYPE(gsl_vector) *v1, const GSL_TYPE(
 }
 
 #ifdef HAVE_TENSOR_TENSOR_H
-EXTERN VALUE cgsl_tensor, cgsl_tensor_int;
+extern VALUE cgsl_tensor, cgsl_tensor_int;
 VALUE rb_gsl_tensor_equal(int argc, VALUE *argv, VALUE obj);
 VALUE rb_gsl_tensor_int_equal(int argc, VALUE *argv, VALUE obj);
 #ifdef BASE_DOUBLE
@@ -3319,3 +3324,7 @@ void FUNCTION(Init_gsl_vector,init)(VALUE module)
 #undef VEC_ROW_P
 #undef CHECK_VEC
 #undef VEC_VIEW_P
+
+#ifdef RUBY_3
+#define memcpy ruby_nonempty_memcpy
+#endif

--- a/ext/gsl_native/vector_source.h
+++ b/ext/gsl_native/vector_source.h
@@ -36,11 +36,6 @@
 #define VEC_VIEW_P VECTOR_INT_VIEW_P
 #endif
 
-// Ruby 3 redefines memcpy as ruby_nonempty_memcpy, breaking everything if memcpy is used in preprocessor
-#ifdef RUBY_3
-#define memcpy memcpy
-#endif
-
 void FUNCTION(get_range,beg_en_n)(VALUE range, BASE *beg, BASE *en, size_t *n, int *step);
 
 void get_range_beg_en_n_for_size(VALUE range,
@@ -3324,7 +3319,3 @@ void FUNCTION(Init_gsl_vector,init)(VALUE module)
 #undef VEC_ROW_P
 #undef CHECK_VEC
 #undef VEC_VIEW_P
-
-#ifdef RUBY_3
-#define memcpy ruby_nonempty_memcpy
-#endif


### PR DESCRIPTION
Due to some changes in Ruby 3, rb-gsl does not compile for this version. This PR:

* Adds 3.0 and all other minor versions to Travis
* Changes `EXTERN` to `extern`
* Solves issues around `RBGSL_SET_CLASS0` and subtle change of behaviour in Ruby 3
* Takes care of Ruby 3 redefining `memcpy`, which broke some macros