### PR TITLE
Fix gcc-14 -Wincompatible-pointer-types

### DIFF
--- a/ext/gsl_native/alf.c
+++ b/ext/gsl_native/alf.c
@@ -189,6 +189,7 @@ void Init_alf(VALUE module)
   VALUE mALF;
   mALF = rb_define_module_under(module, "ALF");
   cWspace = rb_define_class_under(mALF, "Workspace", cGSL_Object);
+  rb_undef_alloc_func(cWspace);
   rb_define_singleton_method(cWspace, "alloc", rb_alf_alloc, 1);
   rb_define_singleton_method(mALF, "alloc", rb_alf_alloc, 1);
   rb_define_module_function(module, "alf_alloc", rb_alf_alloc, 1);

--- a/ext/gsl_native/array.c
+++ b/ext/gsl_native/array.c
@@ -474,69 +474,115 @@ void Init_gsl_array(VALUE module)
 {
   cgsl_block = rb_define_class_under(module, "Block",
                                      cGSL_Object);
+  rb_undef_alloc_func(cgsl_block);
   cgsl_block_int = rb_define_class_under(cgsl_block, "Int",
                                          cGSL_Object);
+  rb_undef_alloc_func(cgsl_block_int);
   cgsl_block_uchar = rb_define_class_under(cgsl_block, "Byte",
                                            cGSL_Object);
+  rb_undef_alloc_func(cgsl_block_uchar);
 
   cgsl_block_complex = rb_define_class_under(cgsl_block, "Complex", cgsl_block);
+  rb_undef_alloc_func(cgsl_block_complex);
+
   cgsl_vector = rb_define_class_under(module, "Vector",
                                       cGSL_Object);
+  rb_undef_alloc_func(cgsl_vector);
+
   cgsl_vector_col = rb_define_class_under(cgsl_vector, "Col",
                                           cgsl_vector);
+  rb_undef_alloc_func(cgsl_vector_col);
+
   cgsl_vector_complex = rb_define_class_under(cgsl_vector, "Complex",
                                               cGSL_Object);
+  rb_undef_alloc_func(cgsl_vector_complex);
+
   cgsl_vector_complex_col = rb_define_class_under(cgsl_vector_complex, "Col",
                                                   cgsl_vector_complex);
+  rb_undef_alloc_func(cgsl_vector_complex_col);
+
   cgsl_matrix = rb_define_class_under(module, "Matrix", cGSL_Object);
+  rb_undef_alloc_func(cgsl_matrix);
+
   cgsl_matrix_complex = rb_define_class_under(cgsl_matrix, "Complex", cGSL_Object);
+  rb_undef_alloc_func(cgsl_matrix_complex);
 
   cgsl_vector_view = rb_define_class_under(cgsl_vector, "View", cgsl_vector);
+  rb_undef_alloc_func(cgsl_vector_view);
+
   cgsl_vector_col_view = rb_define_class_under(cgsl_vector_col, "View", cgsl_vector_col);
+  rb_undef_alloc_func(cgsl_vector_col_view);
 
   cgsl_vector_complex_view = rb_define_class_under(cgsl_vector_complex, "View",
                                                    cgsl_vector_complex);
+  rb_undef_alloc_func(cgsl_vector_complex_view);
   cgsl_vector_complex_col_view = rb_define_class_under(cgsl_vector_complex_col, "View",
                                                        cgsl_vector_complex_col);
+  rb_undef_alloc_func(cgsl_vector_complex_col_view);
 
   cgsl_vector_int = rb_define_class_under(cgsl_vector, "Int", cGSL_Object);
+  rb_undef_alloc_func(cgsl_vector_int);
   cgsl_vector_int_col = rb_define_class_under(cgsl_vector_int, "Col", cgsl_vector_int);
+  rb_undef_alloc_func(cgsl_vector_int_col);
   cgsl_vector_int_view = rb_define_class_under(cgsl_vector_int, "View", cgsl_vector_int);
+  rb_undef_alloc_func(cgsl_vector_int_view);
   cgsl_vector_int_col_view = rb_define_class_under(cgsl_vector_int_col, "View", cgsl_vector_int_col);
-
+  rb_undef_alloc_func(cgsl_vector_int_col_view);
 
   /*****/
 
   cgsl_matrix_view = rb_define_class_under(cgsl_matrix, "View",
                                            cgsl_matrix);
+  rb_undef_alloc_func(cgsl_matrix_view);
+
   cgsl_matrix_complex_view = rb_define_class_under(cgsl_matrix_complex, "View",
                                                    cgsl_matrix_complex);
+  rb_undef_alloc_func(cgsl_matrix_complex_view);
   cgsl_permutation = rb_define_class_under(module, "Permutation", cGSL_Object);
+  rb_undef_alloc_func(cgsl_permutation);
+
   cgsl_index = rb_define_class_under(module, "Index", cgsl_permutation);
+  rb_undef_alloc_func(cgsl_index);
 
   cgsl_vector_view_ro = rb_define_class_under(cgsl_vector_view, "ReadOnly",
                                               cgsl_vector_view);
+  rb_undef_alloc_func(cgsl_vector_view_ro);
+
   cgsl_vector_col_view_ro = rb_define_class_under(cgsl_vector_col_view, "ReadOnly",
                                                   cgsl_vector_col_view);
+  rb_undef_alloc_func(cgsl_vector_col_view_ro);
+
   cgsl_vector_int_view_ro = rb_define_class_under(cgsl_vector_int_view, "ReadOnly",
                                                   cgsl_vector_int_view);
+  rb_undef_alloc_func(cgsl_vector_int_view_ro);
+
   cgsl_vector_int_col_view_ro = rb_define_class_under(cgsl_vector_int_col_view, "ReadOnly",
                                                       cgsl_vector_int_col_view);
+  rb_undef_alloc_func(cgsl_vector_int_col_view_ro);
+
   cgsl_matrix_view_ro = rb_define_class_under(cgsl_matrix_view, "ReadOnly",
                                               cgsl_matrix_view);
+  rb_undef_alloc_func(cgsl_matrix_view_ro);
 
   cgsl_vector_complex_view_ro = rb_define_class_under(cgsl_vector_complex_view,
                                                       "ReadOnly",
                                                       cgsl_vector_complex_view);
+  rb_undef_alloc_func(cgsl_vector_complex_view_ro);
+
   cgsl_matrix_complex_view_ro = rb_define_class_under(cgsl_matrix_complex_view,
                                                       "ReadOnly",
                                                       cgsl_matrix_complex_view);
+  rb_undef_alloc_func(cgsl_matrix_complex_view_ro);
 
   /*****/
   cgsl_matrix_int = rb_define_class_under(cgsl_matrix, "Int", cGSL_Object);
+  rb_undef_alloc_func(cgsl_matrix_int);
   cgsl_matrix_int_view = rb_define_class_under(cgsl_matrix_int, "View", cgsl_matrix_int);
+  rb_undef_alloc_func(cgsl_matrix_int_view);
   cgsl_matrix_int_view_ro = rb_define_class_under(cgsl_matrix_int_view, "ReadOnly",
                                                   cgsl_matrix_int_view);
+  rb_undef_alloc_func(cgsl_matrix_int_view_ro);
+
   /*****/
   Init_gsl_block_init(module);
   Init_gsl_block_int_init(module);

--- a/ext/gsl_native/blas2.c
+++ b/ext/gsl_native/blas2.c
@@ -1081,8 +1081,8 @@ void Init_gsl_blas2(VALUE module)
   rb_define_module_function(module, "zher!", rb_gsl_blas_zher, 4);
   rb_define_module_function(module, "zher", rb_gsl_blas_zher_a, 4);
 
-  rb_define_module_function(module, "dsyr2!", rb_gsl_blas_dsyr2, 4);
-  rb_define_module_function(module, "dsyr2", rb_gsl_blas_dsyr2_a, 4);
-  rb_define_module_function(module, "zher2!", rb_gsl_blas_zher2, 4);
-  rb_define_module_function(module, "zher2", rb_gsl_blas_zher2_a, 4);
+  rb_define_module_function(module, "dsyr2!", rb_gsl_blas_dsyr2, 5);
+  rb_define_module_function(module, "dsyr2", rb_gsl_blas_dsyr2_a, 5);
+  rb_define_module_function(module, "zher2!", rb_gsl_blas_zher2, 5);
+  rb_define_module_function(module, "zher2", rb_gsl_blas_zher2_a, 5);
 }

--- a/ext/gsl_native/bspline.c
+++ b/ext/gsl_native/bspline.c
@@ -47,15 +47,15 @@ static VALUE rb_gsl_bspline_knots(VALUE obj, VALUE b)
     nm_bpts = NM_STORAGE_DENSE(b);
     v = gsl_vector_view_array((double*) nm_bpts->elements, NM_DENSE_COUNT(b));
     gsl_bspline_knots(&v.vector, w);
-    return Data_Wrap_Struct(cgsl_vector_view_ro, 0, NULL, w->knots);    
+    return Data_Wrap_Struct(cgsl_vector_view_ro, 0, NULL, w->knots);
   }
 #endif
-  
+
   gsl_vector *bpts;
   CHECK_VECTOR(b);
   Data_Get_Struct(b, gsl_vector, bpts);
   gsl_bspline_knots(bpts, w);
-  return Data_Wrap_Struct(cgsl_vector_view_ro, 0, NULL, w->knots);    
+  return Data_Wrap_Struct(cgsl_vector_view_ro, 0, NULL, w->knots);
 }
 static VALUE rb_gsl_bspline_knots_uniform(int argc, VALUE *argv, VALUE obj)
 {
@@ -120,6 +120,7 @@ static VALUE rb_gsl_bspline_greville_abscissa(VALUE obj, VALUE i)
 void Init_bspline(VALUE module)
 {
   cBSWS = rb_define_class_under(module, "BSpline", cGSL_Object);
+  rb_undef_alloc_func(cBSWS);
 
   rb_define_singleton_method(cBSWS, "alloc", rb_gsl_bspline_alloc, 2);
 

--- a/ext/gsl_native/cheb.c
+++ b/ext/gsl_native/cheb.c
@@ -122,7 +122,7 @@ static VALUE rb_gsl_cheb_eval(VALUE obj, VALUE xx)
         gsl_vector_set(vnew, i, gsl_cheb_eval(p, gsl_vector_get(v, i)));
       }
       return Data_Wrap_Struct(cgsl_vector, 0, gsl_vector_free, vnew);
-    } 
+    }
 #ifdef HAVE_NMATRIX_H
     else if (NM_IsNMatrix(xx)) {
       NM_DENSE_STORAGE *nm;
@@ -574,6 +574,7 @@ static VALUE rb_gsl_cheb_calc_integ(int argc, VALUE *argv, VALUE obj)
 void Init_gsl_cheb(VALUE module)
 {
   cgsl_cheb = rb_define_class_under(module, "Cheb", cGSL_Object);
+  rb_undef_alloc_func(cgsl_cheb);
   rb_define_singleton_method(cgsl_cheb, "new", rb_gsl_cheb_new, 1);
   rb_define_singleton_method(cgsl_cheb, "alloc", rb_gsl_cheb_new, 1);
   rb_define_method(cgsl_cheb, "order", rb_gsl_cheb_order, 0);

--- a/ext/gsl_native/combination.c
+++ b/ext/gsl_native/combination.c
@@ -241,8 +241,11 @@ void Init_gsl_combination(VALUE module)
 {
   VALUE cgsl_combination;
   cgsl_combination = rb_define_class_under(module, "Combination", cGSL_Object);
+  rb_undef_alloc_func(cgsl_combination);
   cgsl_combination_data = rb_define_class_under(cgsl_combination, "Data",
                                                 cgsl_permutation);
+  rb_undef_alloc_func(cgsl_combination_data);
+
   rb_define_singleton_method(cgsl_combination, "new", rb_gsl_combination_new, 2);
   rb_define_singleton_method(cgsl_combination, "alloc", rb_gsl_combination_new, 2);
   rb_define_singleton_method(cgsl_combination, "calloc", rb_gsl_combination_calloc, 2);
@@ -272,4 +275,3 @@ void Init_gsl_combination(VALUE module)
   rb_define_method(cgsl_combination, "equal?", rb_gsl_combination_equal, 1);
   rb_define_alias(cgsl_combination, "==", "equal?");
 }
-

--- a/ext/gsl_native/complex.c
+++ b/ext/gsl_native/complex.c
@@ -881,6 +881,7 @@ static VALUE rb_gsl_complex_inspect(VALUE obj)
 void Init_gsl_complex(VALUE module)
 {
   cgsl_complex = rb_define_class_under(module, "Complex",  rb_cNumeric);
+  rb_undef_alloc_func(cgsl_complex);
   rb_define_singleton_method(cgsl_complex, "alloc", rb_gsl_complex_new, -1);
   rb_define_singleton_method(cgsl_complex, "rect", rb_gsl_complex_new, -1);
   rb_define_singleton_method(cgsl_complex, "[]", rb_gsl_complex_new, -1);

--- a/ext/gsl_native/cqp.c
+++ b/ext/gsl_native/cqp.c
@@ -238,7 +238,9 @@ void Init_cqp(VALUE module)
 
   mCQP = rb_define_module_under(module, "CQP");
   cMinimizer = rb_define_class_under(mCQP, "Minimizer", cGSL_Object);
+  rb_undef_alloc_func(cMinimizer);
   cData = rb_define_class_under(mCQP, "Data", cGSL_Object);
+  rb_undef_alloc_func(cData);
 
   rb_define_singleton_method(cMinimizer, "alloc", rb_cqpminimizer_alloc, 4);
 
@@ -280,4 +282,3 @@ void Init_cqp(VALUE module)
 }
 
 #endif
-

--- a/ext/gsl_native/dht.c
+++ b/ext/gsl_native/dht.c
@@ -355,6 +355,8 @@ void Init_gsl_dht(VALUE module)
 {
   VALUE cgsl_dht;
   cgsl_dht = rb_define_class_under(module, "Dht", cGSL_Object);
+  rb_undef_alloc_func(cgsl_dht);
+
   rb_define_singleton_method(cgsl_dht, "alloc", rb_gsl_dht_alloc, -1);
   rb_define_method(cgsl_dht, "init", rb_gsl_dht_init, 2);
   rb_define_method(cgsl_dht, "apply", rb_gsl_dht_apply, -1);

--- a/ext/gsl_native/dirac.c
+++ b/ext/gsl_native/dirac.c
@@ -73,13 +73,18 @@ static void Init_gsl_dirac_common(VALUE module)
 
   cgsl_matrix_complex_const = rb_define_class_under(module, "Const",
                                                     cgsl_matrix_complex);
+  rb_undef_alloc_func(cgsl_matrix_complex_const);
   rb_define_method(cgsl_matrix_complex_const, "set", rb_dirac_refuse_set, -1);
 
   cPauli = rb_define_class_under(module, "Pauli", cgsl_matrix_complex_const);
+  rb_undef_alloc_func(cPauli);
   cAlpha = rb_define_class_under(module, "Alpha", cgsl_matrix_complex_const);
+  rb_undef_alloc_func(cAlpha);
   /*  cBeta = rb_define_class_under(module, "BetaMatrix", cgsl_matrix_complex_const);*/
   cGamma = rb_define_class_under(module, "Gamma", cgsl_matrix_complex_const);
+  rb_undef_alloc_func(cGamma);
   cLambda = rb_define_class_under(module, "Lambda", cgsl_matrix_complex_const);
+  rb_undef_alloc_func(cLambda);
 }
 
 

--- a/ext/gsl_native/eigen.c
+++ b/ext/gsl_native/eigen.c
@@ -2221,23 +2221,39 @@ void Init_gsl_eigen(VALUE module)
 
   cgsl_eigen_values = rb_define_class_under(mgsl_eigen, "EigenValues",
                                             cgsl_vector);
+  rb_undef_alloc_func(cgsl_eigen_values);
+
   cgsl_eigen_vectors = rb_define_class_under(mgsl_eigen, "EigenVectors",
                                              cgsl_matrix);
+  rb_undef_alloc_func(cgsl_eigen_vectors);
+
   cgsl_eigen_vector = rb_define_class_under(mgsl_eigen, "EigenVector",
                                             cgsl_vector);
+  rb_undef_alloc_func(cgsl_eigen_vector);
+
   cgsl_eigen_herm_vectors = rb_define_class_under(mgsl_eigen, "ComplexEigenVectors",
                                                   cgsl_matrix_complex);
+  rb_undef_alloc_func(cgsl_eigen_herm_vectors);
+
   cgsl_eigen_vector_complex = rb_define_class_under(mgsl_eigen, "ComplexEigenVector",
                                                     cgsl_vector_complex);
+  rb_undef_alloc_func(cgsl_eigen_vector_complex);
+
   cgsl_eigen_symm_workspace = rb_define_class_under(mgsl_eigen_symm,
                                                     "Workspace", cGSL_Object);
+  rb_undef_alloc_func(cgsl_eigen_symm_workspace);
+
   cgsl_eigen_symmv_workspace = rb_define_class_under(mgsl_eigen_symmv,
                                                      "Workspace", cGSL_Object);
+  rb_undef_alloc_func(cgsl_eigen_symmv_workspace);
+
   cgsl_eigen_herm_workspace = rb_define_class_under(mgsl_eigen_herm,
                                                     "Workspace", cGSL_Object);
+  rb_undef_alloc_func(cgsl_eigen_herm_workspace);
 
   cgsl_eigen_hermv_workspace = rb_define_class_under(mgsl_eigen_hermv,
                                                      "Workspace", cGSL_Object);
+  rb_undef_alloc_func(cgsl_eigen_hermv_workspace);
 
   rb_define_singleton_method(cgsl_eigen_symm_workspace, "alloc",
                              rb_gsl_eigen_symm_alloc, 1);
@@ -2298,6 +2314,8 @@ void Init_gsl_eigen(VALUE module)
   mgsl_eigen_francis = rb_define_module_under(mgsl_eigen, "francis");
   cgsl_eigen_francis_workspace = rb_define_class_under(mgsl_eigen_francis,
                                                        "Workspace", cGSL_Object);
+  rb_undef_alloc_func(cgsl_eigen_francis_workspace);
+
   rb_define_singleton_method(cgsl_eigen_francis_workspace, "alloc",
                              rb_gsl_eigen_francis_alloc, 0);
 
@@ -2317,6 +2335,8 @@ void Init_gsl_eigen(VALUE module)
   mgsl_eigen_nonsymmv = rb_define_module_under(mgsl_eigen, "Nonsymmv");
   cgsl_eigen_nonsymm_workspace = rb_define_class_under(mgsl_eigen_nonsymm,
                                                        "Workspace", cGSL_Object);
+  rb_undef_alloc_func(cgsl_eigen_nonsymm_workspace);
+
   rb_define_singleton_method(cgsl_eigen_nonsymm_workspace, "alloc",
                              rb_gsl_eigen_nonsymm_alloc, 1);
   rb_define_singleton_method(mgsl_eigen_nonsymm, "alloc",
@@ -2334,6 +2354,8 @@ void Init_gsl_eigen(VALUE module)
 
   cgsl_eigen_nonsymmv_workspace = rb_define_class_under(mgsl_eigen_nonsymmv,
                                                         "Workspace", cGSL_Object);
+  rb_undef_alloc_func(cgsl_eigen_nonsymmv_workspace);
+
   rb_define_singleton_method(cgsl_eigen_nonsymmv_workspace, "alloc",
                              rb_gsl_eigen_nonsymmv_alloc, 1);
   rb_define_singleton_method(mgsl_eigen_nonsymmv, "alloc",
@@ -2357,8 +2379,11 @@ void Init_gsl_eigen(VALUE module)
   /** gensymm, gensymmv **/
   mgensymm = rb_define_module_under(mgsl_eigen, "Gensymm");
   cgensymm = rb_define_class_under(mgensymm, "Workspace", cGSL_Object);
+  rb_undef_alloc_func(cgensymm);
+
   mgensymmv = rb_define_module_under(mgsl_eigen, "Gensymmv");
   cgensymmv = rb_define_class_under(mgensymmv, "Workspace", cGSL_Object);
+  rb_undef_alloc_func(cgensymmv);
 
   rb_define_singleton_method(cgensymm, "alloc", rb_gsl_eigen_gensymm_alloc, 1);
   rb_define_singleton_method(cgensymmv, "alloc", rb_gsl_eigen_gensymmv_alloc, 1);
@@ -2385,8 +2410,11 @@ void Init_gsl_eigen(VALUE module)
   /** genherm, genhermv **/
   mgenherm = rb_define_module_under(mgsl_eigen, "Genherm");
   cgenherm = rb_define_class_under(mgenherm, "Workspace", cGSL_Object);
+  rb_undef_alloc_func(cgenherm);
+
   mgenhermv = rb_define_module_under(mgsl_eigen, "Genhermv");
   cgenhermv = rb_define_class_under(mgenhermv, "Workspace", cGSL_Object);
+  rb_undef_alloc_func(cgenhermv);
 
   rb_define_singleton_method(cgenherm, "alloc", rb_gsl_eigen_genherm_alloc, 1);
   rb_define_singleton_method(cgenhermv, "alloc", rb_gsl_eigen_genhermv_alloc, 1);
@@ -2414,7 +2442,10 @@ void Init_gsl_eigen(VALUE module)
   mgen = rb_define_module_under(mgsl_eigen, "Gen");
   mgenv = rb_define_module_under(mgsl_eigen, "Genv");
   cgenw = rb_define_class_under(mgen, "Workspace", cGSL_Object);
+  rb_undef_alloc_func(cgenw);
   cgenvw = rb_define_class_under(mgenv, "Workspace", cGSL_Object);
+  rb_undef_alloc_func(cgenvw);
+
   rb_define_singleton_method(mgen, "alloc", rb_gsl_eigen_gen_alloc, 1);
   rb_define_singleton_method(cgenw, "alloc", rb_gsl_eigen_gen_alloc, 1);
   rb_define_singleton_method(mgenv, "alloc", rb_gsl_eigen_genv_alloc, 1);
@@ -2448,4 +2479,3 @@ void Init_gsl_eigen(VALUE module)
   rb_define_module_function(module, "eigen_genv_sort",
                             rb_gsl_eigen_genv_sort, -1);
 }
-

--- a/ext/gsl_native/fft.c
+++ b/ext/gsl_native/fft.c
@@ -990,6 +990,7 @@ void Init_gsl_fft(VALUE module)
   // GSL::FFT::Real::Wavetable
   // GSL::FFT::HalfComplex::Wavetable
   cgsl_fft_wavetable = rb_define_class_under(mgsl_fft, "Wavetable", cGSL_Object);
+  rb_undef_alloc_func(cgsl_fft_wavetable);
   // No alloc
   // TODO Make GSL::FFT::Wavetable#initialize private?
   rb_define_method(cgsl_fft_wavetable, "n",
@@ -1002,12 +1003,15 @@ void Init_gsl_fft(VALUE module)
   // class GSL::FFT::ComplexWavetable < GSL::FFT::Wavetable
   cgsl_fft_complex_wavetable = rb_define_class_under(mgsl_fft, "ComplexWavetable",
                                                      cgsl_fft_wavetable);
+  rb_undef_alloc_func(cgsl_fft_complex_wavetable);
   rb_define_singleton_method(cgsl_fft_complex_wavetable, "alloc",
                              rb_gsl_fft_complex_wavetable_new, 1);
 
   // class GSL::FFT::ComplexWorkspace < GSL::Object
   cgsl_fft_complex_workspace = rb_define_class_under(mgsl_fft, "ComplexWorkspace",
                                                      cGSL_Object);
+  rb_undef_alloc_func(cgsl_fft_complex_workspace);
+
   rb_define_singleton_method(cgsl_fft_complex_workspace, "alloc",
                              rb_gsl_fft_complex_workspace_new, 1);
 
@@ -1060,12 +1064,16 @@ void Init_gsl_fft(VALUE module)
   // class GSL::FFT::RealWavetable < GSL::FFT::Wavetable
   cgsl_fft_real_wavetable = rb_define_class_under(mgsl_fft, "RealWavetable",
                                                   cgsl_fft_wavetable);
+  rb_undef_alloc_func(cgsl_fft_real_wavetable);
+
   rb_define_singleton_method(cgsl_fft_real_wavetable, "alloc",
                              rb_gsl_fft_real_wavetable_new, 1);
 
   // class GSL::FFT::HalfComplexWavetable < GSL::FFT::Wavetable
   cgsl_fft_halfcomplex_wavetable = rb_define_class_under(mgsl_fft,
                                                          "HalfComplexWavetable", cgsl_fft_wavetable);
+  rb_undef_alloc_func(cgsl_fft_halfcomplex_wavetable);
+
   rb_define_singleton_method(cgsl_fft_halfcomplex_wavetable, "alloc",
                              rb_gsl_fft_halfcomplex_wavetable_new, 1);
 
@@ -1074,6 +1082,8 @@ void Init_gsl_fft(VALUE module)
   // class GSL::FFT::RealWorkspace < GSL::Object
   cgsl_fft_real_workspace = rb_define_class_under(mgsl_fft, "RealWorkspace",
                                                   cGSL_Object);
+  rb_undef_alloc_func(cgsl_fft_real_workspace);
+
   rb_define_singleton_method(cgsl_fft_real_workspace, "alloc",
                              rb_gsl_fft_real_workspace_new, 1);
 

--- a/ext/gsl_native/function.c
+++ b/ext/gsl_native/function.c
@@ -501,7 +501,9 @@ void Init_gsl_function(VALUE module)
   RBGSL_ID_arity = rb_intern("arity");
 
   cgsl_function = rb_define_class_under(module, "Function", cGSL_Object);
+  rb_undef_alloc_func(cgsl_function);
   cgsl_function_fdf = rb_define_class_under(module, "Function_fdf", cGSL_Object);
+  rb_undef_alloc_func(cgsl_function_fdf);
   // This Fdf class seems superfluous.  Should probably be deleted?
   rb_define_class_under(cgsl_function_fdf, "Fdf", cgsl_function_fdf);
 

--- a/ext/gsl_native/graph.c
+++ b/ext/gsl_native/graph.c
@@ -1303,6 +1303,7 @@ void Init_gsl_graph(VALUE module)
   VALUE cgsl_graph;
 
   cgsl_graph = rb_define_class_under(module, "Graph", cGSL_Object);
+  rb_undef_alloc_func(cgsl_graph);
 
   rb_define_singleton_method(cgsl_graph, "new", rb_gsl_graph_new, -1);
   rb_define_singleton_method(cgsl_graph, "alloc", rb_gsl_graph_new, -1);

--- a/ext/gsl_native/gsl.c
+++ b/ext/gsl_native/gsl.c
@@ -27,7 +27,7 @@ static VALUE rb_gsl_object_inspect(VALUE obj)
   return rb_str_new2(buf);
 }
 
-static VALUE rb_gsl_call_rescue(VALUE obj)
+static VALUE rb_gsl_call_rescue(VALUE obj, VALUE error)
 {
   return Qfalse;
 }

--- a/ext/gsl_native/gsl_narray.c
+++ b/ext/gsl_native/gsl_narray.c
@@ -731,9 +731,9 @@ void Init_gsl_narray(VALUE module)
   rb_define_alias(cNArray, "to_gslv_int_view", "to_gv_int_view");
   /*****/
 
-  rb_define_method(cgsl_matrix, "to_na", rb_gsl_matrix_to_na, 0);
+  rb_define_method(cgsl_matrix, "to_na", rb_gsl_matrix_to_na, 1);
   rb_define_alias(cgsl_matrix, "to_narray", "to_na");
-  rb_define_method(cgsl_matrix, "to_nm", rb_gsl_matrix_to_nmatrix, 0);
+  rb_define_method(cgsl_matrix, "to_nm", rb_gsl_matrix_to_nmatrix, 1);
   rb_define_alias(cgsl_matrix, "to_nmatrix", "to_nm");
   rb_define_method(cgsl_matrix, "to_na2", rb_gsl_matrix_to_na_ref, 0);
   rb_define_alias(cgsl_matrix, "to_na_ref", "to_na2");

--- a/ext/gsl_native/histogram.c
+++ b/ext/gsl_native/histogram.c
@@ -1852,12 +1852,16 @@ void Init_gsl_histogram(VALUE module)
   VALUE cgsl_histogram_pdf;
 
   cgsl_histogram = rb_define_class_under(module, "Histogram", cGSL_Object);
+  rb_undef_alloc_func(cgsl_histogram);
   cgsl_histogram_range = rb_define_class_under(cgsl_histogram, "Range",
                                                cgsl_vector_view_ro);
+  rb_undef_alloc_func(cgsl_histogram_range);
   cgsl_histogram_bin = rb_define_class_under(cgsl_histogram, "Bin",
                                              cgsl_vector_view);
+  rb_undef_alloc_func(cgsl_histogram_bin);
   cgsl_histogram_integ = rb_define_class_under(cgsl_histogram, "Integral",
                                                cgsl_histogram);
+  rb_undef_alloc_func(cgsl_histogram_integ);
 
   rb_define_singleton_method(cgsl_histogram, "alloc", rb_gsl_histogram_alloc, -1);
   /*  rb_define_singleton_method(cgsl_histogram, "new", rb_gsl_histogram_alloc, -1);*/
@@ -1957,6 +1961,8 @@ void Init_gsl_histogram(VALUE module)
   rb_define_method(cgsl_histogram, "print", rb_gsl_histogram_print, 0);
 
   cgsl_histogram_pdf = rb_define_class_under(cgsl_histogram, "Pdf", cGSL_Object);
+  rb_undef_alloc_func(cgsl_histogram_pdf);
+
   rb_define_singleton_method(cgsl_histogram_pdf, "alloc",
                              rb_gsl_histogram_pdf_alloc, 1);
   /*  rb_define_singleton_method(cgsl_histogram_pdf, "new",

--- a/ext/gsl_native/histogram2d.c
+++ b/ext/gsl_native/histogram2d.c
@@ -474,7 +474,7 @@ static VALUE rb_gsl_histogram2d_add(VALUE obj, VALUE hh2)
     Need_Float(hh2);
     gsl_histogram2d_shift(hnew, NUM2DBL(hh2));
   }
-  return Data_Wrap_Struct(CLASS_OF(h1), 0, gsl_histogram2d_free, hnew);
+  return Data_Wrap_Struct(CLASS_OF((VALUE)h1), 0, gsl_histogram2d_free, hnew);
 }
 
 static VALUE rb_gsl_histogram2d_sub(VALUE obj, VALUE hh2)
@@ -489,7 +489,7 @@ static VALUE rb_gsl_histogram2d_sub(VALUE obj, VALUE hh2)
     Need_Float(hh2);
     gsl_histogram2d_shift(hnew, -NUM2DBL(hh2));
   }
-  return Data_Wrap_Struct(CLASS_OF(h1), 0, gsl_histogram2d_free, hnew);
+  return Data_Wrap_Struct(CLASS_OF((VALUE)h1), 0, gsl_histogram2d_free, hnew);
 }
 
 static VALUE rb_gsl_histogram2d_mul(VALUE obj, VALUE hh2)
@@ -504,7 +504,7 @@ static VALUE rb_gsl_histogram2d_mul(VALUE obj, VALUE hh2)
     Need_Float(hh2);
     gsl_histogram2d_scale(hnew, NUM2DBL(hh2));
   }
-  return Data_Wrap_Struct(CLASS_OF(h1), 0, gsl_histogram2d_free, hnew);
+  return Data_Wrap_Struct(CLASS_OF((VALUE)h1), 0, gsl_histogram2d_free, hnew);
 }
 
 static VALUE rb_gsl_histogram2d_div(VALUE obj, VALUE hh2)
@@ -519,7 +519,7 @@ static VALUE rb_gsl_histogram2d_div(VALUE obj, VALUE hh2)
     Need_Float(hh2);
     gsl_histogram2d_scale(hnew, 1.0/NUM2DBL(hh2));
   }
-  return Data_Wrap_Struct(CLASS_OF(h1), 0, gsl_histogram2d_free, hnew);
+  return Data_Wrap_Struct(CLASS_OF((VALUE)h1), 0, gsl_histogram2d_free, hnew);
 }
 
 static VALUE rb_gsl_histogram2d_scale2(VALUE obj, VALUE val)
@@ -529,7 +529,7 @@ static VALUE rb_gsl_histogram2d_scale2(VALUE obj, VALUE val)
   Data_Get_Struct(obj, gsl_histogram2d, h1);
   hnew = gsl_histogram2d_clone(h1);
   gsl_histogram2d_scale(hnew, NUM2DBL(val));
-  return Data_Wrap_Struct(CLASS_OF(h1), 0, gsl_histogram2d_free, hnew);
+  return Data_Wrap_Struct(CLASS_OF((VALUE)h1), 0, gsl_histogram2d_free, hnew);
 }
 
 static VALUE rb_gsl_histogram2d_shift2(VALUE obj, VALUE val)
@@ -539,7 +539,7 @@ static VALUE rb_gsl_histogram2d_shift2(VALUE obj, VALUE val)
   Data_Get_Struct(obj, gsl_histogram2d, h1);
   hnew = gsl_histogram2d_clone(h1);
   gsl_histogram2d_shift(hnew, NUM2DBL(val));
-  return Data_Wrap_Struct(CLASS_OF(h1), 0, gsl_histogram2d_free, hnew);
+  return Data_Wrap_Struct(CLASS_OF((VALUE)h1), 0, gsl_histogram2d_free, hnew);
 }
 
 static VALUE rb_gsl_histogram2d_fwrite(VALUE obj, VALUE io)
@@ -1006,7 +1006,7 @@ void Init_gsl_histogram2d(VALUE module)
   rb_define_method(cgsl_histogram2d, "fwrite2",  rb_gsl_histogram2d_fwrite2, 1);
   rb_define_method(cgsl_histogram2d, "fread2",  rb_gsl_histogram2d_fread2, 1);
   rb_define_method(cgsl_histogram2d, "fprintf",  rb_gsl_histogram2d_fprintf, -1);
-  rb_define_method(cgsl_histogram2d, "fscanf",  rb_gsl_histogram2d_fscanf, 3);
+  rb_define_method(cgsl_histogram2d, "fscanf",  rb_gsl_histogram2d_fscanf, 1);
 
   cgsl_histogram2d_pdf = rb_define_class_under(cgsl_histogram2d, "Pdf", cGSL_Object);
 
@@ -1039,4 +1039,3 @@ void Init_gsl_histogram2d(VALUE module)
 #ifdef CHECK_HISTOGRAM2D
 #undef CHECK_HISTOGRAM2D
 #endif
-

--- a/ext/gsl_native/histogram2d.c
+++ b/ext/gsl_native/histogram2d.c
@@ -923,11 +923,14 @@ void Init_gsl_histogram2d(VALUE module)
   VALUE cgsl_histogram2d_pdf;
 
   cgsl_histogram2d = rb_define_class_under(module, "Histogram2d", cGSL_Object);
+  rb_undef_alloc_func(cgsl_histogram2d);
   cgsl_histogram2d_view = rb_define_class_under(cgsl_histogram2d, "View",
                                                 cgsl_histogram);
+  rb_undef_alloc_func(cgsl_histogram2d_view);
 
   cgsl_histogram2d_integ = rb_define_class_under(cgsl_histogram2d, "Integral",
                                                  cgsl_histogram2d);
+  rb_undef_alloc_func(cgsl_histogram2d_integ);
 
   /*  rb_define_singleton_method(cgsl_histogram2d, "new", rb_gsl_histogram2d_alloc, -1);*/
   rb_define_singleton_method(cgsl_histogram2d, "alloc", rb_gsl_histogram2d_alloc, -1);
@@ -1009,6 +1012,7 @@ void Init_gsl_histogram2d(VALUE module)
   rb_define_method(cgsl_histogram2d, "fscanf",  rb_gsl_histogram2d_fscanf, 1);
 
   cgsl_histogram2d_pdf = rb_define_class_under(cgsl_histogram2d, "Pdf", cGSL_Object);
+  rb_undef_alloc_func(cgsl_histogram2d_pdf);
 
   /*  rb_define_singleton_method(cgsl_histogram2d_pdf, "new",
       rb_gsl_histogram2d_pdf_alloc, 2);*/

--- a/ext/gsl_native/histogram3d.c
+++ b/ext/gsl_native/histogram3d.c
@@ -781,8 +781,10 @@ static VALUE rb_gsl_histogram3d_div_scale(VALUE obj, VALUE hh)
 void Init_gsl_histogram3d(VALUE module)
 {
   cgsl_histogram3d = rb_define_class_under(module, "Histogram3d", cGSL_Object);
+  rb_undef_alloc_func(cgsl_histogram3d);
   cgsl_histogram3d_view = rb_define_class_under(cgsl_histogram3d, "View",
                                                 cgsl_histogram2d);
+  rb_undef_alloc_func(cgsl_histogram3d_view);
 
   /*  rb_define_singleton_method(cgsl_histogram3d, "new", rb_gsl_histogram3d_new, -1);*/
   rb_define_singleton_method(cgsl_histogram3d, "alloc",

--- a/ext/gsl_native/ieee.c
+++ b/ext/gsl_native/ieee.c
@@ -81,8 +81,8 @@ void Init_gsl_ieee(VALUE module)
   rb_define_singleton_method(mgsl_ieee, "fprintf",
                              rb_gsl_ieee_fprintf_double, -1);
   rb_define_singleton_method(mgsl_ieee, "printf",
-                             rb_gsl_ieee_printf_double, -1);
+                             rb_gsl_ieee_printf_double, 1);
   rb_define_singleton_method(mgsl_ieee, "printf_double",
-                             rb_gsl_ieee_printf_double, -1);
+                             rb_gsl_ieee_printf_double, 1);
 
 }

--- a/ext/gsl_native/integration.c
+++ b/ext/gsl_native/integration.c
@@ -1062,6 +1062,7 @@ void Init_gsl_integration(VALUE module)
 
   cgsl_integration_qaws_table = rb_define_class_under(mgsl_integ, "QAWS_Table",
                                                       cGSL_Object);
+  rb_undef_alloc_func(cgsl_integration_qaws_table);
   rb_define_singleton_method(cgsl_integration_qaws_table, "alloc",
                              rb_gsl_integration_qaws_table_alloc, -1);
   /*  rb_define_singleton_method(cgsl_integration_qaws_table, "new",
@@ -1078,6 +1079,7 @@ void Init_gsl_integration(VALUE module)
 
   cgsl_integration_qawo_table = rb_define_class_under(mgsl_integ, "QAWO_Table",
                                                       cGSL_Object);
+  rb_undef_alloc_func(cgsl_integration_qawo_table);
   rb_define_singleton_method(cgsl_integration_qawo_table, "alloc",
                              rb_gsl_integration_qawo_table_alloc, -1);
   /*  rb_define_singleton_method(cgsl_integration_qawo_table, "new",
@@ -1097,6 +1099,7 @@ void Init_gsl_integration(VALUE module)
 
   cgsl_integration_workspace = rb_define_class_under(mgsl_integ,
                                                      "Workspace", cGSL_Object);
+  rb_undef_alloc_func(cgsl_integration_workspace);
 
   /*  rb_define_singleton_method(cgsl_integration_workspace, "new",
       rb_gsl_integration_workspace_alloc, -1);*/
@@ -1138,6 +1141,7 @@ void Init_gsl_integration(VALUE module)
   rb_define_module_function(mgsl_integ, "qawf", rb_gsl_integration_qawf, -1);
 
   cgsl_integration_glfixed_table = rb_define_class_under(mgsl_integ, "Glfixed_table", cGSL_Object);
+  rb_undef_alloc_func(cgsl_integration_glfixed_table);
   rb_define_singleton_method(cgsl_integration_glfixed_table, "alloc",
                              rb_gsl_integration_glfixed_table_alloc, 1);
   rb_define_method(cgsl_function, "glfixed", rb_gsl_integration_glfixed, 3);
@@ -1151,4 +1155,3 @@ void Init_gsl_integration(VALUE module)
 #ifdef CHECK_WORKSPACE
 #undef CHECK_WORKSPACE
 #endif
-

--- a/ext/gsl_native/interp2d.c
+++ b/ext/gsl_native/interp2d.c
@@ -15,7 +15,7 @@ VALUE cgsl_interp2d_accel; /* this is used also in spline2d.c */
 extern VALUE cgsl_vector, cgsl_matrix;
 
 static VALUE rb_gsl_interp2d_alloc(int argc, VALUE *argv, VALUE self)
-{ 
+{
   rb_gsl_interp2d *sp = NULL;
   const gsl_interp2d_type *T = NULL;
   double *xptr = NULL, *yptr = NULL, *zptr = NULL;
@@ -63,8 +63,8 @@ static VALUE rb_gsl_interp2d_init(VALUE self, VALUE xarr, VALUE yarr, VALUE zarr
 }
 
 static VALUE rb_gsl_interp_evaluate(
-  VALUE self, VALUE xarr, VALUE yarr, VALUE zarr, VALUE xx, VALUE yy, 
-    double (*eval)(const gsl_interp2d * interp, 
+  VALUE self, VALUE xarr, VALUE yarr, VALUE zarr, VALUE xx, VALUE yy,
+    double (*eval)(const gsl_interp2d * interp,
       const double xa[], const double ya[], const double za[],
       const double x, const double y, gsl_interp_accel * xacc,
       gsl_interp_accel * yacc))
@@ -77,7 +77,7 @@ static VALUE rb_gsl_interp_evaluate(
     xx = yy;
     yy = temp;
   }
-  
+
   rb_gsl_interp2d *rgi = NULL;
   double *xptr = NULL, *yptr = NULL, *zptr = NULL;
   gsl_vector *vx = NULL, *vy = NULL, *vnew = NULL;
@@ -89,19 +89,19 @@ static VALUE rb_gsl_interp_evaluate(
   Data_Get_Struct(self, rb_gsl_interp2d, rgi);
   xptr = get_vector_ptr(xarr, &stridex, &xsize);
   if (xsize != rgi->p->xsize ) {
-    rb_raise(rb_eTypeError, "size mismatch (xa:%d != %d)",  (int) xsize, 
+    rb_raise(rb_eTypeError, "size mismatch (xa:%d != %d)",  (int) xsize,
       (int) rgi->p->xsize);
   }
 
   yptr = get_vector_ptr(yarr, &stridey, &ysize);
   if (ysize != rgi->p->ysize ) {
-    rb_raise(rb_eTypeError, "size mismatch (ya:%d != %d)", (int) ysize, 
+    rb_raise(rb_eTypeError, "size mismatch (ya:%d != %d)", (int) ysize,
       (int) rgi->p->ysize);
   }
 
   zptr = get_vector_ptr(zarr, &stridez, &zsize);
   if (zsize != xsize*ysize ) {
-    rb_raise(rb_eTypeError, "size mismatch (za:%d != %d)", (int) zsize, 
+    rb_raise(rb_eTypeError, "size mismatch (za:%d != %zu)", (int) zsize,
       (int) xsize*ysize);
   }
 
@@ -145,7 +145,7 @@ static VALUE rb_gsl_interp_evaluate(
       vnew = gsl_vector_alloc(vx->size);
 
       for (i = 0; i < vx->size; i++) {
-        val = (*eval)(rgi->p, xptr, yptr, zptr, gsl_vector_get(vx, i), 
+        val = (*eval)(rgi->p, xptr, yptr, zptr, gsl_vector_get(vx, i),
           gsl_vector_get(vy, i), rgi->xacc, rgi->yacc);
         gsl_vector_set(vnew, i, val);
       }
@@ -199,7 +199,7 @@ static void rb_gsl_interp2d_define_const(VALUE self)
 }
 
 const gsl_interp2d_type* get_interp2d_type(VALUE t)
-{ 
+{
   int type;
   char name[32];
 
@@ -212,7 +212,7 @@ const gsl_interp2d_type* get_interp2d_type(VALUE t)
         case 1: return gsl_interp2d_bilinear; break;
         default:
           rb_raise(rb_eRuntimeError, "Cannot recognize type %d.\n", type);
-      } 
+      }
     case T_STRING:
       strcpy(name, STR2CSTR(t));
 

--- a/ext/gsl_native/interp2d.c
+++ b/ext/gsl_native/interp2d.c
@@ -253,7 +253,9 @@ void Init_gsl_interp2d(VALUE module)
   VALUE cgsl_interp2d;
 
   cgsl_interp2d = rb_define_class_under(module, "Interp2d", cGSL_Object);
+  rb_undef_alloc_func(cgsl_interp2d);
   cgsl_interp2d_accel = rb_define_class_under(cgsl_interp2d, "Accel", cGSL_Object);
+  rb_undef_alloc_func(cgsl_interp2d_accel);
 
   rb_define_singleton_method(cgsl_interp2d, "alloc", rb_gsl_interp2d_alloc, -1);
   rb_gsl_interp2d_define_const(cgsl_interp2d);

--- a/ext/gsl_native/jacobi.c
+++ b/ext/gsl_native/jacobi.c
@@ -671,6 +671,7 @@ void Init_jacobi(VALUE module)
   mjac = rb_define_module("Jac");
   jac_define_const(mjac);
   cjacq = rb_define_class_under(mjac, "Quadrature", cGSL_Object);
+  rb_undef_alloc_func(cjacq);
 
   rb_define_module_function(mjac, "jacobi_P0_e", rb_jac_jacobi_P0_e, 3);
   rb_define_module_function(mjac, "jacobi_P0", rb_jac_jacobi_P0, 3);
@@ -730,4 +731,3 @@ void Init_jacobi(VALUE module)
 }
 
 #endif
-

--- a/ext/gsl_native/linalg.c
+++ b/ext/gsl_native/linalg.c
@@ -92,13 +92,13 @@ static VALUE rb_gsl_linalg_LU_decomp_nmatrix(int argc, VALUE *argv, VALUE obj,
     rb_raise(rb_eRuntimeError, "square matrix required");
 
   if (flag == LINALG_DECOMP) {
-    m = rb_nmatrix_dense_create(FLOAT64, input_nmatrix->shape, 2, 
+    m = rb_nmatrix_dense_create(FLOAT64, input_nmatrix->shape, 2,
       input_nmatrix->elements, input_nmatrix->shape[0] * input_nmatrix->shape[1]);
     temp_nmatrix = NM_STORAGE_DENSE(m);
-    mv = gsl_matrix_view_array((double*)temp_nmatrix->elements, 
+    mv = gsl_matrix_view_array((double*)temp_nmatrix->elements,
       temp_nmatrix->shape[0], temp_nmatrix->shape[1]);
   } else {
-    mv = gsl_matrix_view_array((double*)input_nmatrix->elements, 
+    mv = gsl_matrix_view_array((double*)input_nmatrix->elements,
       input_nmatrix->shape[0], input_nmatrix->shape[1]);
   }
   p = gsl_permutation_alloc(mv.matrix.size1);
@@ -304,7 +304,7 @@ static VALUE rb_gsl_linalg_LU_solve_nmatrix(int argc, VALUE *argv, VALUE obj)
              argc);
   }
   input_nmatrix = NM_STORAGE_DENSE(argv[0]);
-  mv = gsl_matrix_view_array((double*) input_nmatrix->elements, 
+  mv = gsl_matrix_view_array((double*) input_nmatrix->elements,
     input_nmatrix->shape[0], input_nmatrix->shape[1]);
   CHECK_PERMUTATION(argv[1]);
   Data_Get_Struct(argv[1], gsl_permutation, p);
@@ -542,11 +542,11 @@ static VALUE rb_gsl_linalg_LU_invert_nmatrix(int argc, VALUE *argv, VALUE obj)
 
   CHECK_PERMUTATION(argv[1]);
   lu_nmatrix = NM_STORAGE_DENSE(argv[0]);
-  inv = rb_nmatrix_dense_create(FLOAT64, lu_nmatrix->shape, 2, 
+  inv = rb_nmatrix_dense_create(FLOAT64, lu_nmatrix->shape, 2,
     lu_nmatrix->elements, NM_DENSE_COUNT(argv[0]));
-  mv1 = gsl_matrix_view_array((double*)lu_nmatrix->elements, 
+  mv1 = gsl_matrix_view_array((double*)lu_nmatrix->elements,
     lu_nmatrix->shape[0], lu_nmatrix->shape[1]);
-  mv2 = gsl_matrix_view_array((double*)NM_DENSE_ELEMENTS(inv), 
+  mv2 = gsl_matrix_view_array((double*)NM_DENSE_ELEMENTS(inv),
     lu_nmatrix->shape[0], lu_nmatrix->shape[1]);
 
   Data_Get_Struct(argv[1], gsl_permutation, p);
@@ -620,7 +620,7 @@ static VALUE rb_gsl_linalg_LU_det_nmatrix(int argc, VALUE *argv, VALUE obj)
   /* no break */
   case 1:
     input_nmatrix = NM_STORAGE_DENSE(argv[0]);
-    mv = gsl_matrix_view_array((double*)input_nmatrix->elements, 
+    mv = gsl_matrix_view_array((double*)input_nmatrix->elements,
       input_nmatrix->shape[0], input_nmatrix->shape[1]);
     break;
   default:
@@ -965,7 +965,7 @@ static VALUE rb_gsl_linalg_QR_decomp_nmatrix(int argc, VALUE *argv, VALUE obj)
   shapem[0] = nm->shape[1];
   shapem[1] = nm->shape[1];
   shapev[0] = shapem[0];
-  qr = rb_nmatrix_dense_create(FLOAT64, shapem, 2, nm->elements, 
+  qr = rb_nmatrix_dense_create(FLOAT64, shapem, 2, nm->elements,
     shapem[0]*shapem[1]);
   tau = rb_nmatrix_dense_create(FLOAT64, shapev, 1, nm->elements, shapev[0]);
   mv = gsl_matrix_view_array((double*)NM_DENSE_ELEMENTS(qr), shapem[0], shapem[1]);
@@ -1696,10 +1696,10 @@ static VALUE rb_gsl_linalg_R_solve(int argc, VALUE *argv, VALUE obj)
 }
 
 /* singleton */
-static VALUE rb_gsl_linalg_QR_QRsolve(int argc, VALUE *argv, VALUE obj,
-                                      int flag)
+static VALUE rb_gsl_linalg_QR_QRsolve(VALUE argc, VALUE argv, VALUE obj,
+                                      VALUE flag)
 {
-  return rb_gsl_linalg_QRLQ_QRLQsolve(argc, argv, obj, LINALG_QR_DECOMP);
+  return rb_gsl_linalg_QRLQ_QRLQsolve((int)argc, &argv, obj, LINALG_QR_DECOMP);
 }
 
 static VALUE rb_gsl_linalg_LQ_Lsolve(int argc, VALUE *argv, VALUE obj)
@@ -1718,10 +1718,10 @@ static VALUE rb_gsl_linalg_L_solve(int argc, VALUE *argv, VALUE obj)
 }
 
 /* singleton */
-static VALUE rb_gsl_linalg_LQ_LQsolve(int argc, VALUE *argv, VALUE obj,
-                                      int flag)
+static VALUE rb_gsl_linalg_LQ_LQsolve(VALUE argc, VALUE argv, VALUE obj,
+                                      VALUE flag)
 {
-  return rb_gsl_linalg_QRLQ_QRLQsolve(argc, argv, obj, LINALG_LQ_DECOMP);
+  return rb_gsl_linalg_QRLQ_QRLQsolve((int)argc, &argv, obj, LINALG_LQ_DECOMP);
 }
 
 static VALUE rb_gsl_linalg_QRLQ_update(VALUE obj, VALUE qq, VALUE rr, VALUE ww,
@@ -4049,12 +4049,12 @@ void Init_gsl_linalg(VALUE module)
   rb_define_method(cgsl_matrix_QR, "Rsolve", rb_gsl_linalg_QR_Rsolve, -1);
 
   rb_define_module_function(mgsl_linalg_QR, "Rsvx", rb_gsl_linalg_QR_Rsvx, -1);
-  rb_define_method(cgsl_matrix_QR, "Rsvx", rb_gsl_linalg_QR_Rsvx, 1);
+  rb_define_method(cgsl_matrix_QR, "Rsvx", rb_gsl_linalg_QR_Rsvx, -1);
 
   rb_define_module_function(mgsl_linalg_QR, "unpack", rb_gsl_linalg_QR_unpack, -1);
   rb_define_method(cgsl_matrix_QR, "unpack", rb_gsl_linalg_QR_unpack, -1);
 
-  rb_define_module_function(mgsl_linalg_QR, "QRsolve", rb_gsl_linalg_QR_QRsolve, -1);
+  rb_define_module_function(mgsl_linalg_QR, "QRsolve", rb_gsl_linalg_QR_QRsolve, 3);
   rb_define_module_function(mgsl_linalg_QR, "update", rb_gsl_linalg_QR_update, 4);
 
   rb_define_method(mgsl_linalg, "R_solve", rb_gsl_linalg_R_solve, -1);
@@ -4250,12 +4250,12 @@ void Init_gsl_linalg(VALUE module)
   rb_define_method(cgsl_matrix_LQ, "Lsolve_T", rb_gsl_linalg_LQ_Lsolve, -1);
 
   rb_define_module_function(mgsl_linalg_LQ, "Lsvx_T", rb_gsl_linalg_LQ_Lsvx, -1);
-  rb_define_method(cgsl_matrix_LQ, "Lsvx_T", rb_gsl_linalg_LQ_Lsvx, 1);
+  rb_define_method(cgsl_matrix_LQ, "Lsvx_T", rb_gsl_linalg_LQ_Lsvx, -1);
 
   rb_define_module_function(mgsl_linalg_LQ, "unpack", rb_gsl_linalg_LQ_unpack, -1);
   rb_define_method(cgsl_matrix_LQ, "unpack", rb_gsl_linalg_LQ_unpack, -1);
 
-  rb_define_module_function(mgsl_linalg_LQ, "LQsolve_T", rb_gsl_linalg_LQ_LQsolve, -1);
+  rb_define_module_function(mgsl_linalg_LQ, "LQsolve_T", rb_gsl_linalg_LQ_LQsolve, 3);
   rb_define_module_function(mgsl_linalg_LQ, "update", rb_gsl_linalg_LQ_update, 4);
 
   rb_define_method(mgsl_linalg, "L_solve_T", rb_gsl_linalg_L_solve, -1);

--- a/ext/gsl_native/linalg.c
+++ b/ext/gsl_native/linalg.c
@@ -3943,30 +3943,44 @@ void Init_gsl_linalg(VALUE module)
   mgsl_linalg = rb_define_module_under(module, "Linalg");
   mgsl_linalg_LU = rb_define_module_under(mgsl_linalg, "LU");
   cgsl_matrix_LU = rb_define_class_under(mgsl_linalg_LU, "LUMatrix", cgsl_matrix);
+  rb_undef_alloc_func(cgsl_matrix_LU);
   mgsl_linalg_QR = rb_define_module_under(mgsl_linalg, "QR");
   mgsl_linalg_QRPT = rb_define_module_under(mgsl_linalg, "QRPT");
   cgsl_matrix_QR = rb_define_class_under(mgsl_linalg, "QRMatrix", cgsl_matrix);
+  rb_undef_alloc_func(cgsl_matrix_QR);
   cgsl_matrix_QRPT = rb_define_class_under(mgsl_linalg, "QRPTMatrix", cgsl_matrix);
+  rb_undef_alloc_func(cgsl_matrix_QRPT);
   cgsl_vector_tau = rb_define_class_under(mgsl_linalg, "TauVector", cgsl_vector);
+  rb_undef_alloc_func(cgsl_vector_tau);
   cgsl_matrix_Q = rb_define_class_under(mgsl_linalg, "QMatrix", cgsl_matrix);
+  rb_undef_alloc_func(cgsl_matrix_Q);
   cgsl_matrix_R = rb_define_class_under(mgsl_linalg, "RMatrix", cgsl_matrix);
+  rb_undef_alloc_func(cgsl_matrix_R);
 
   mgsl_linalg_LQ = rb_define_module_under(mgsl_linalg, "LQ");
   mgsl_linalg_PTLQ = rb_define_module_under(mgsl_linalg, "PTLQ");
   cgsl_matrix_LQ = rb_define_class_under(mgsl_linalg, "LQMatrix", cgsl_matrix);
+  rb_undef_alloc_func(cgsl_matrix_LQ);
   cgsl_matrix_PTLQ = rb_define_class_under(mgsl_linalg, "PTLQMatrix", cgsl_matrix);
+  rb_undef_alloc_func(cgsl_matrix_PTLQ);
   cgsl_matrix_L = rb_define_class_under(mgsl_linalg, "LMatrix", cgsl_matrix);
+  rb_undef_alloc_func(cgsl_matrix_L);
 
   /*****/
   mgsl_linalg_SV = rb_define_module_under(mgsl_linalg, "SV");
   cgsl_matrix_SV = rb_define_class_under(mgsl_linalg_SV, "SVMatrix", cgsl_matrix);
+  rb_undef_alloc_func(cgsl_matrix_SV);
   cgsl_matrix_U = rb_define_class_under(mgsl_linalg_SV, "UMatrix", cgsl_matrix);
+  rb_undef_alloc_func(cgsl_matrix_U);
   cgsl_matrix_V = rb_define_class_under(mgsl_linalg_SV, "VMatrix", cgsl_matrix);
+  rb_undef_alloc_func(cgsl_matrix_V);
   cgsl_vector_S = rb_define_class_under(mgsl_linalg_SV, "SingularValues", cgsl_vector);
+  rb_undef_alloc_func(cgsl_vector_S);
 
   /*****/
   mgsl_linalg_cholesky = rb_define_module_under(mgsl_linalg, "Cholesky");
   cgsl_matrix_C = rb_define_class_under(mgsl_linalg_cholesky, "CholeskyMatrix", cgsl_matrix);
+  rb_undef_alloc_func(cgsl_matrix_C);
   mgsl_linalg_symmtd = rb_define_module_under(mgsl_linalg, "Symmtd");
 
   mgsl_linalg_hermtd = rb_define_module_under(mgsl_linalg, "Hermtd");

--- a/ext/gsl_native/linalg_complex.c
+++ b/ext/gsl_native/linalg_complex.c
@@ -615,6 +615,7 @@ void Init_gsl_linalg_complex(VALUE module)
 
   cgsl_matrix_complex_LU = rb_define_class_under(mgsl_linalg_complex_LU,
                                                  "LUMatrix", cgsl_matrix_complex);
+  rb_undef_alloc_func(cgsl_matrix_complex_LU);
 
   rb_define_singleton_method(mgsl_linalg_complex, "LU_decomp!",
                              rb_gsl_linalg_complex_LU_decomp, -1);
@@ -692,6 +693,8 @@ void Init_gsl_linalg_complex(VALUE module)
 
   mgsl_linalg_complex_chol = rb_define_module_under(mgsl_linalg_complex, "Cholesky");
   cgsl_matrix_complex_C = rb_define_class_under(mgsl_linalg_complex_chol, "CholeskyMatrix", cgsl_matrix_complex);
+  rb_undef_alloc_func(cgsl_matrix_complex_C);
+
   rb_define_singleton_method(mgsl_linalg_complex_chol, "decomp", rb_gsl_linalg_cholesky_decomp, -1);
   rb_define_method(cgsl_matrix_complex, "cholesky_decomp", rb_gsl_linalg_cholesky_decomp, -1);
   rb_define_singleton_method(mgsl_linalg_complex_chol, "solve", rb_gsl_linalg_cholesky_solve, -1);

--- a/ext/gsl_native/matrix_complex.c
+++ b/ext/gsl_native/matrix_complex.c
@@ -1424,7 +1424,7 @@ static VALUE rb_gsl_matrix_complex_arccoth(VALUE obj)
   return rb_gsl_matrix_complex_XXX_complex(obj, gsl_complex_arccoth);
 }
 
-static VALUE rb_gsl_matrix_complex_indgen_bang(int argc, VALUE *argv[], VALUE obj)
+static VALUE rb_gsl_matrix_complex_indgen_bang(int argc, VALUE argv[], VALUE obj)
 {
   gsl_matrix_complex *m = NULL;
   double start = 0, step = 1, x;

--- a/ext/gsl_native/min.c
+++ b/ext/gsl_native/min.c
@@ -184,6 +184,7 @@ void Init_gsl_min(VALUE module)
   mgsl_min = rb_define_module_under(module, "Min");
 
   cgsl_fminimizer = rb_define_class_under(mgsl_min, "FMinimizer", cGSL_Object);
+  rb_undef_alloc_func(cgsl_fminimizer);
 
   rb_define_const(cgsl_fminimizer, "GOLDENSECTION",
                   INT2FIX(GSL_MIN_FMINIMIZER_GOLDENSECTION));

--- a/ext/gsl_native/monte.c
+++ b/ext/gsl_native/monte.c
@@ -852,7 +852,7 @@ void Init_gsl_monte(VALUE module)
   rb_define_singleton_method(cgsl_monte_function, "alloc", rb_gsl_monte_function_new, -1);
 
   rb_define_method(cgsl_monte_function, "proc", rb_gsl_monte_function_proc, 0);
-  rb_define_method(cgsl_monte_function, "eval", rb_gsl_monte_function_eval, 0);
+  rb_define_method(cgsl_monte_function, "eval", rb_gsl_monte_function_eval, 1);
   rb_define_alias(cgsl_monte_function, "call", "eval");
   rb_define_method(cgsl_monte_function, "params", rb_gsl_monte_function_params, 0);
   rb_define_method(cgsl_monte_function, "set", rb_gsl_monte_function_set_f, -1);

--- a/ext/gsl_native/monte.c
+++ b/ext/gsl_native/monte.c
@@ -844,9 +844,13 @@ void Init_gsl_monte(VALUE module)
   rb_define_const(mgsl_monte, "VEGAS", INT2FIX(GSL_MONTE_VEGAS_STATE));
 
   cgsl_monte_function = rb_define_class_under(mgsl_monte, "Function", cGSL_Object);
+  rb_undef_alloc_func(cgsl_monte_function);
   cgsl_monte_plain = rb_define_class_under(mgsl_monte, "Plain", cGSL_Object);
+  rb_undef_alloc_func(cgsl_monte_plain);
   cgsl_monte_miser = rb_define_class_under(mgsl_monte, "Miser", cGSL_Object);
+  rb_undef_alloc_func(cgsl_monte_miser);
   cgsl_monte_vegas = rb_define_class_under(mgsl_monte, "Vegas", cGSL_Object);
+  rb_undef_alloc_func(cgsl_monte_vegas);
 
   rb_define_singleton_method(cgsl_monte_function, "new", rb_gsl_monte_function_new, -1);
   rb_define_singleton_method(cgsl_monte_function, "alloc", rb_gsl_monte_function_new, -1);
@@ -929,7 +933,9 @@ void Init_gsl_monte(VALUE module)
                    rb_gsl_monte_vegas_integrate, -1);
 
   cgsl_monte_miser_params = rb_define_class_under(cgsl_monte_miser, "Params", cGSL_Object);
+  rb_undef_alloc_func(cgsl_monte_miser_params);
   cgsl_monte_vegas_params = rb_define_class_under(cgsl_monte_vegas, "Params", cGSL_Object);
+  rb_undef_alloc_func(cgsl_monte_vegas_params);
 
   rb_define_method(cgsl_monte_miser, "params_get", rb_gsl_monte_miser_params_get, 0);
   rb_define_method(cgsl_monte_miser, "params_set", rb_gsl_monte_miser_params_set, 1);

--- a/ext/gsl_native/multifit.c
+++ b/ext/gsl_native/multifit.c
@@ -1822,6 +1822,7 @@ void Init_gsl_multifit(VALUE module)
 
   cgsl_multifit_workspace = rb_define_class_under(mgsl_multifit, "Workspace",
                                                   cGSL_Object);
+  rb_undef_alloc_func(cgsl_multifit_workspace);
   rb_define_singleton_method(cgsl_multifit_workspace, "new",
                              rb_gsl_multifit_workspace_new, 2);
   rb_define_singleton_method(cgsl_multifit_workspace, "alloc",
@@ -1832,10 +1833,13 @@ void Init_gsl_multifit(VALUE module)
   rb_define_module_function(mgsl_multifit, "wlinear", rb_gsl_multifit_wlinear, -1);
 
   cgsl_multifit_solver = rb_define_class_under(mgsl_multifit, "Solver", cGSL_Object);
+  rb_undef_alloc_func(cgsl_multifit_solver);
   cgsl_multifit_fdfsolver = rb_define_class_under(mgsl_multifit, "FdfSolver",
                                                   cgsl_multifit_solver);
+  rb_undef_alloc_func(cgsl_multifit_fdfsolver);
   cgsl_multifit_function_fdf = rb_define_class_under(mgsl_multifit, "Function_fdf",
                                                      cGSL_Object);
+  rb_undef_alloc_func(cgsl_multifit_function_fdf);
 
   /*****/
 

--- a/ext/gsl_native/multimin.c
+++ b/ext/gsl_native/multimin.c
@@ -715,11 +715,14 @@ void Init_gsl_multimin(VALUE module)
   rb_define_singleton_method(mgsl_multimin, "test_size", rb_gsl_multimin_test_size, 2);
 
   cgsl_multimin_fdfminimizer = rb_define_class_under(mgsl_multimin, "FdfMinimizer", cGSL_Object);
+  rb_undef_alloc_func(cgsl_multimin_fdfminimizer);
   cgsl_multimin_fminimizer = rb_define_class_under(mgsl_multimin, "FMinimizer", cGSL_Object);
+  rb_undef_alloc_func(cgsl_multimin_fminimizer);
   define_const(cgsl_multimin_fdfminimizer, cgsl_multimin_fminimizer);
 
   cgsl_multimin_function = rb_define_class_under(mgsl_multimin, "Function",
                                                  cgsl_function);
+  rb_undef_alloc_func(cgsl_multimin_function);
   rb_define_singleton_method(cgsl_multimin_function, "alloc",
                              rb_gsl_multimin_function_new, -1);
   rb_define_method(cgsl_multimin_function, "eval", rb_gsl_multimin_function_eval, 1);
@@ -732,6 +735,7 @@ void Init_gsl_multimin(VALUE module)
 
   cgsl_multimin_function_fdf = rb_define_class_under(mgsl_multimin, "Function_fdf",
                                                      cGSL_Object);
+  rb_undef_alloc_func(cgsl_multimin_function_fdf);
   rb_define_singleton_method(cgsl_multimin_function_fdf, "alloc",
                              rb_gsl_multimin_function_fdf_new, -1);
 
@@ -775,4 +779,3 @@ void Init_gsl_multimin(VALUE module)
 #ifdef CHECK_MULTIMIN_FUNCTION_FDF
 #undef CHECK_MULTIMIN_FUNCTION_FDF
 #endif
-

--- a/ext/gsl_native/multimin_fsdf.c
+++ b/ext/gsl_native/multimin_fsdf.c
@@ -137,7 +137,9 @@ void Init_multimin_fsdf(VALUE module)
   VALUE cmin;
 
   cmin = rb_define_class_under(module, "FsdfMinimizer",  cGSL_Object);
+  rb_undef_alloc_func(cmin);
   cfsdf = rb_define_class_under(module, "Function_fsdf", cgsl_multimin_function_fdf);
+  rb_undef_alloc_func(cfsdf);
 
   rb_define_singleton_method(cmin, "alloc", rb_gsl_fsdfminimizer_alloc, 2);
   rb_define_method(cmin, "set", rb_gsl_fsdfminimizer_set, 3);

--- a/ext/gsl_native/multiroots.c
+++ b/ext/gsl_native/multiroots.c
@@ -99,7 +99,7 @@ static void gsl_multiroot_function_mark(gsl_multiroot_function *f)
   size_t i;
   rb_gc_mark((VALUE) f->params);
   //  for (i = 0; i < RARRAY(f->params)->len; i++)
-  for (i = 0; (int) i < RARRAY_LEN(f->params); i++)
+  for (i = 0; (int) i < RARRAY_LEN((size_t)f->params); i++)
     rb_gc_mark(rb_ary_entry((VALUE) f->params, i));
 }
 
@@ -236,7 +236,7 @@ static void gsl_multiroot_function_fdf_mark(gsl_multiroot_function_fdf *f)
   size_t i;
   rb_gc_mark((VALUE) f->params);
   //  for (i = 0; i < RARRAY(f->params)->len; i++)
-  for (i = 0; (int) i < RARRAY_LEN(f->params); i++)
+  for (i = 0; (int) i < RARRAY_LEN((size_t)f->params); i++)
     rb_gc_mark(rb_ary_entry((VALUE) f->params, i));
 }
 

--- a/ext/gsl_native/multiroots.c
+++ b/ext/gsl_native/multiroots.c
@@ -876,6 +876,7 @@ void Init_gsl_multiroot(VALUE module)
   /* multiroot_function */
   cgsl_multiroot_function = rb_define_class_under(mgsl_multiroot, "Function",
                                                   cgsl_function);
+  rb_undef_alloc_func(cgsl_multiroot_function);
   rb_define_singleton_method(cgsl_multiroot_function, "alloc",
                              rb_gsl_multiroot_function_new, -1);
   rb_define_method(cgsl_multiroot_function, "eval", rb_gsl_multiroot_function_eval, 1);
@@ -889,6 +890,7 @@ void Init_gsl_multiroot(VALUE module)
   /* multiroot_function_fdf */
   cgsl_multiroot_function_fdf = rb_define_class_under(mgsl_multiroot, "Function_fdf",
                                                       cgsl_multiroot_function);
+  rb_undef_alloc_func(cgsl_multiroot_function_fdf);
   rb_define_singleton_method(cgsl_multiroot_function_fdf, "alloc",
                              rb_gsl_multiroot_function_fdf_new, -1);
   rb_define_method(cgsl_multiroot_function_fdf, "set", rb_gsl_multiroot_function_fdf_set, -1);
@@ -900,8 +902,9 @@ void Init_gsl_multiroot(VALUE module)
 
   /* solver */
   cgsl_multiroot_fsolver = rb_define_class_under(mgsl_multiroot, "FSolver", cGSL_Object);
+  rb_undef_alloc_func(cgsl_multiroot_fsolver);
   cgsl_multiroot_fdfsolver = rb_define_class_under(mgsl_multiroot, "FdfSolver", cgsl_multiroot_fsolver);
-
+  rb_undef_alloc_func(cgsl_multiroot_fdfsolver);
   rb_define_singleton_method(cgsl_multiroot_fsolver, "alloc",
                              rb_gsl_multiroot_fsolver_new, 2);
   rb_define_singleton_method(cgsl_multiroot_fdfsolver, "alloc",

--- a/ext/gsl_native/multiset.c
+++ b/ext/gsl_native/multiset.c
@@ -182,6 +182,7 @@ VALUE rb_gsl_multiset_data2(VALUE mm, VALUE i)
 void Init_multiset(VALUE module)
 {
   cMultiset = rb_define_class_under(module, "Multiset", cGSL_Object);
+  rb_undef_alloc_func(cMultiset);
   rb_define_singleton_method(cMultiset, "alloc", rb_gsl_multiset_alloc, 2);
   rb_define_singleton_method(cMultiset, "calloc", rb_gsl_multiset_calloc, 2);
   rb_define_singleton_method(cMultiset, "memcpy", rb_gsl_multiset_memcpy, 2);
@@ -207,4 +208,3 @@ void Init_multiset(VALUE module)
   rb_define_method(cMultiset, "fprintf", rb_gsl_multiset_fprintf, 2);
   rb_define_method(cMultiset, "fscanf", rb_gsl_multiset_fscanf, 1);
 }
-

--- a/ext/gsl_native/ntuple.c
+++ b/ext/gsl_native/ntuple.c
@@ -434,9 +434,9 @@ void Init_gsl_ntuple(VALUE module)
   rb_define_singleton_method(cgsl_ntuple, "create", rb_gsl_ntuple_new, -1);
   rb_define_singleton_method(cgsl_ntuple, "alloc", rb_gsl_ntuple_new, -1);
   rb_define_singleton_method(cgsl_ntuple, "open", rb_gsl_ntuple_open, -1);
-  rb_define_singleton_method(cgsl_ntuple, "close", rb_gsl_ntuple_close, 0);
+  rb_define_singleton_method(cgsl_ntuple, "close", rb_gsl_ntuple_close, 1);
 
-  rb_define_method(cgsl_ntuple, "size", rb_gsl_ntuple_size, 0);
+  rb_define_method(cgsl_ntuple, "size", rb_gsl_ntuple_size, 1);
   rb_define_method(cgsl_ntuple, "write", rb_gsl_ntuple_write, 0);
   rb_define_method(cgsl_ntuple, "bookdata", rb_gsl_ntuple_bookdata, 0);
 

--- a/ext/gsl_native/ntuple.c
+++ b/ext/gsl_native/ntuple.c
@@ -428,8 +428,11 @@ static VALUE rb_gsl_ntuple_project2(VALUE obj, VALUE hh, VALUE vvfn, VALUE vsfn)
 void Init_gsl_ntuple(VALUE module)
 {
   cgsl_ntuple = rb_define_class_under(module, "Ntuple", cGSL_Object);
+  rb_undef_alloc_func(cgsl_ntuple);
   cgsl_ntuple_select_fn = rb_define_class_under(cgsl_ntuple, "SelectFn", cGSL_Object);
+  rb_undef_alloc_func(cgsl_ntuple_select_fn);
   cgsl_ntuple_value_fn = rb_define_class_under(cgsl_ntuple, "ValueFn", cGSL_Object);
+  rb_undef_alloc_func(cgsl_ntuple_value_fn);
 
   rb_define_singleton_method(cgsl_ntuple, "create", rb_gsl_ntuple_new, -1);
   rb_define_singleton_method(cgsl_ntuple, "alloc", rb_gsl_ntuple_new, -1);

--- a/ext/gsl_native/odeiv.c
+++ b/ext/gsl_native/odeiv.c
@@ -882,7 +882,7 @@ void Init_gsl_odeiv(VALUE module)
   rb_define_singleton_method(cgsl_odeiv_control, "standard_alloc", rb_gsl_odeiv_control_standard_new, 4);
   rb_define_singleton_method(cgsl_odeiv_control, "y_new", rb_gsl_odeiv_control_y_new, 2);
   rb_define_singleton_method(cgsl_odeiv_control, "yp_new", rb_gsl_odeiv_control_yp_new, 2);
-  rb_define_singleton_method(cgsl_odeiv_control, "scaled_alloc", rb_gsl_odeiv_control_scaled_new, 5);
+  rb_define_singleton_method(cgsl_odeiv_control, "scaled_alloc", rb_gsl_odeiv_control_scaled_new, 6);
 
   rb_define_method(cgsl_odeiv_control, "init", rb_gsl_odeiv_control_init, 4);
   rb_define_method(cgsl_odeiv_control, "name", rb_gsl_odeiv_control_name, 0);

--- a/ext/gsl_native/odeiv.c
+++ b/ext/gsl_native/odeiv.c
@@ -850,6 +850,7 @@ void Init_gsl_odeiv(VALUE module)
   rb_define_const(mgsl_odeiv, "HADJ_NIL", INT2FIX(GSL_ODEIV_HADJ_NIL));
   cgsl_odeiv_step = rb_define_class_under(mgsl_odeiv, "Step",
                                           cGSL_Object);
+  rb_undef_alloc_func(cgsl_odeiv_step);
   rb_define_singleton_method(cgsl_odeiv_step, "alloc", rb_gsl_odeiv_step_new, -1);
 
   /*****/
@@ -878,6 +879,7 @@ void Init_gsl_odeiv(VALUE module)
 
   cgsl_odeiv_control = rb_define_class_under(mgsl_odeiv, "Control",
                                              cGSL_Object);
+  rb_undef_alloc_func(cgsl_odeiv_control);
   rb_define_singleton_method(cgsl_odeiv_control, "alloc", rb_gsl_odeiv_control_standard_new, 4);
   rb_define_singleton_method(cgsl_odeiv_control, "standard_alloc", rb_gsl_odeiv_control_standard_new, 4);
   rb_define_singleton_method(cgsl_odeiv_control, "y_new", rb_gsl_odeiv_control_y_new, 2);
@@ -891,6 +893,7 @@ void Init_gsl_odeiv(VALUE module)
   /****/
   cgsl_odeiv_evolve = rb_define_class_under(mgsl_odeiv, "Evolve",
                                             cGSL_Object);
+  rb_undef_alloc_func(cgsl_odeiv_evolve);
   rb_define_singleton_method(cgsl_odeiv_evolve, "alloc", rb_gsl_odeiv_evolve_new, 1);
 
   rb_define_method(cgsl_odeiv_evolve, "reset", rb_gsl_odeiv_evolve_reset, 0);
@@ -905,6 +908,7 @@ void Init_gsl_odeiv(VALUE module)
 
   cgsl_odeiv_system = rb_define_class_under(mgsl_odeiv, "System",
                                             cGSL_Object);
+  rb_undef_alloc_func(cgsl_odeiv_system);
   rb_define_singleton_method(cgsl_odeiv_system, "alloc", rb_gsl_odeiv_system_new, -1);
   rb_define_method(cgsl_odeiv_system, "set", rb_gsl_odeiv_system_set, -1);
   rb_define_method(cgsl_odeiv_system, "set_params",
@@ -922,6 +926,7 @@ void Init_gsl_odeiv(VALUE module)
 
   /*****/
   cgsl_odeiv_solver = rb_define_class_under(mgsl_odeiv, "Solver", cGSL_Object);
+  rb_undef_alloc_func(cgsl_odeiv_solver);
   rb_define_singleton_method(cgsl_odeiv_solver, "alloc", rb_gsl_odeiv_solver_new, -1);
   rb_define_method(cgsl_odeiv_solver, "step", rb_gsl_odeiv_solver_step, 0);
   rb_define_method(cgsl_odeiv_solver, "control", rb_gsl_odeiv_solver_control, 0);

--- a/ext/gsl_native/ool.c
+++ b/ext/gsl_native/ool.c
@@ -803,11 +803,17 @@ void Init_ool(VALUE module)
   mOOL = rb_define_module("OOL");
   mConmin = rb_define_module_under(mOOL, "Conmin");
   cool_conmin_function = rb_define_class_under(mConmin, "Function", cgsl_function);
+  rb_undef_alloc_func(cool_conmin_function);
   cool_conmin_constraint = rb_define_class_under(mConmin, "Constraint", cGSL_Object);
+  rb_undef_alloc_func(cool_conmin_constraint);
   cool_conmin_minimizer = rb_define_class_under(mConmin, "Minimizer", cGSL_Object);
+  rb_undef_alloc_func(cool_conmin_minimizer);
   cool_conmin_pgrad = rb_define_class_under(cool_conmin_minimizer, "Pgrad", cGSL_Object);
+  rb_undef_alloc_func(cool_conmin_pgrad);
   cool_conmin_spg = rb_define_class_under(cool_conmin_minimizer, "Spg", cGSL_Object);
+  rb_undef_alloc_func(cool_conmin_spg);
   cool_conmin_gencan = rb_define_class_under(cool_conmin_minimizer, "Gencan", cGSL_Object);
+  rb_undef_alloc_func(cool_conmin_gencan);
 
   def_const(mOOL);
 
@@ -864,10 +870,13 @@ void Init_ool(VALUE module)
 
   cool_conmin_pgrad_parameters = rb_define_class_under(cool_conmin_pgrad, "Parameters",
                                                        rb_cArray);
+  rb_undef_alloc_func(cool_conmin_pgrad_parameters);
   cool_conmin_spg_parameters = rb_define_class_under(cool_conmin_spg, "Parameters",
                                                      rb_cArray);
+  rb_undef_alloc_func(cool_conmin_spg_parameters);
   cool_conmin_gencan_parameters = rb_define_class_under(cool_conmin_gencan, "Parameters",
                                                         rb_cArray);
+  rb_undef_alloc_func(cool_conmin_gencan_parameters);
   rb_define_singleton_method(cool_conmin_pgrad, "parameters_default",
                              rb_ool_conmin_pgrad_parameters_default, 0);
   rb_define_singleton_method(cool_conmin_spg, "parameters_default",

--- a/ext/gsl_native/poly_source.h
+++ b/ext/gsl_native/poly_source.h
@@ -1811,9 +1811,9 @@ void FUNCTION(Init_gsl_poly,init)(VALUE module)
                              FUNCTION(rb_gsl_poly,deconv2), 2);
 
   rb_define_method(GSL_TYPE(cgsl_poly), "reduce",
-                   FUNCTION(rb_gsl_poly,reduce), 1);
-  rb_define_method(GSL_TYPE(cgsl_poly), "deriv", FUNCTION(rb_gsl_poly,deriv), 1);
-  rb_define_method(GSL_TYPE(cgsl_poly), "integ", FUNCTION(rb_gsl_poly,integ), 1);
+                   FUNCTION(rb_gsl_poly,reduce), 0);
+  rb_define_method(GSL_TYPE(cgsl_poly), "deriv", FUNCTION(rb_gsl_poly,deriv), 0);
+  rb_define_method(GSL_TYPE(cgsl_poly), "integ", FUNCTION(rb_gsl_poly,integ), 0);
 
 /*****/
 

--- a/ext/gsl_native/poly_source.h
+++ b/ext/gsl_native/poly_source.h
@@ -1701,12 +1701,15 @@ void FUNCTION(Init_gsl_poly,init)(VALUE module)
 #ifdef BASE_DOUBLE
   VALUE mgsl_poly_complex;
   cgsl_poly = rb_define_class_under(module, "Poly", cgsl_vector);
+  rb_undef_alloc_func(cgsl_poly);
   cgsl_poly_int = rb_define_class_under(cgsl_poly, "Int", cgsl_vector_int);
-
+  rb_undef_alloc_func(cgsl_poly_int);
   cgsl_poly_workspace = rb_define_class_under(cgsl_poly, "Workspace", cGSL_Object);
+  rb_undef_alloc_func(cgsl_poly_workspace);
   mgsl_poly_complex = rb_define_module_under(cgsl_poly, "Complex");
   cgsl_poly_complex_workspace = rb_define_class_under(mgsl_poly_complex,
                                                       "Workspace", cGSL_Object);
+  rb_undef_alloc_func(cgsl_poly_complex_workspace);
   rb_define_singleton_method(cgsl_poly_workspace, "alloc",
                              rb_gsl_poly_workspace_new, 1);
   rb_define_singleton_method(cgsl_poly_complex_workspace, "alloc",
@@ -1790,7 +1793,9 @@ void FUNCTION(Init_gsl_poly,init)(VALUE module)
   rb_define_singleton_method(cgsl_poly, "complex_eval", rb_gsl_poly_eval_singleton, 2);
   rb_define_method(cgsl_vector_complex, "eval", rb_gsl_complex_poly_complex_eval, 1);
   cgsl_poly_dd = rb_define_class_under(cgsl_poly, "DividedDifference", cgsl_poly);
+  rb_undef_alloc_func(cgsl_poly_dd);
   cgsl_poly_taylor = rb_define_class_under(cgsl_poly, "Taylor", cgsl_poly);
+  rb_undef_alloc_func(cgsl_poly_taylor);
   rb_define_singleton_method(cgsl_poly, "dd_init", rb_gsl_poly_dd_init, 2);
 
   rb_define_method(cgsl_poly_dd, "eval",rb_gsl_poly_dd_eval, 2);

--- a/ext/gsl_native/qrng.c
+++ b/ext/gsl_native/qrng.c
@@ -138,6 +138,7 @@ void Init_gsl_qrng(VALUE module)
 {
   VALUE cgsl_qrng;
   cgsl_qrng = rb_define_class_under(module, "QRng", cGSL_Object);
+  rb_undef_alloc_func(cgsl_qrng);
 
   rb_define_singleton_method(cgsl_qrng, "new", rb_gsl_qrng_new, 2);
   rb_define_singleton_method(cgsl_qrng, "alloc", rb_gsl_qrng_new, 2);

--- a/ext/gsl_native/randist.c
+++ b/ext/gsl_native/randist.c
@@ -1870,6 +1870,7 @@ void Init_gsl_ran(VALUE module)
   /*****/
 
   cgsl_ran_discrete = rb_define_class_under(mgsl_ran, "Discrete", cGSL_Object);
+  rb_undef_alloc_func(cgsl_ran_discrete);
   rb_define_singleton_method(cgsl_ran_discrete, "alloc", rb_gsl_ran_discrete_new, 1);
   rb_define_singleton_method(cgsl_ran_discrete, "preproc", rb_gsl_ran_discrete_new, 1);
   rb_define_method(cgsl_rng, "discrete", rb_gsl_ran_discrete, 1);

--- a/ext/gsl_native/rational.c
+++ b/ext/gsl_native/rational.c
@@ -440,6 +440,7 @@ static VALUE rb_gsl_poly_inverse(VALUE obj)
 void Init_gsl_rational(VALUE module)
 {
   cgsl_rational = rb_define_class_under(module, "Rational", cGSL_Object);
+  rb_undef_alloc_func(cgsl_rational);
   rb_define_singleton_method(cgsl_rational, "new", rb_gsl_rational_new, -1);
   rb_define_singleton_method(cgsl_rational, "[]", rb_gsl_rational_new, -1);
   rb_define_singleton_method(cgsl_rational, "alloc", rb_gsl_rational_new, -1);

--- a/ext/gsl_native/rng.c
+++ b/ext/gsl_native/rng.c
@@ -465,21 +465,21 @@ static VALUE rb_gsl_rng_name(VALUE obj)
   return rb_str_new2(gsl_rng_name(r));
 }
 
-static VALUE rb_gsl_rng_max(VALUE obj, VALUE s)
+static VALUE rb_gsl_rng_max(VALUE obj)
 {
   gsl_rng *r = NULL;
   Data_Get_Struct(obj, gsl_rng, r);
   return UINT2NUM(gsl_rng_max(r));
 }
 
-static VALUE rb_gsl_rng_min(VALUE obj, VALUE s)
+static VALUE rb_gsl_rng_min(VALUE obj)
 {
   gsl_rng *r = NULL;
   Data_Get_Struct(obj, gsl_rng, r);
   return UINT2NUM(gsl_rng_min(r));
 }
 
-static VALUE rb_gsl_rng_size(VALUE obj, VALUE s)
+static VALUE rb_gsl_rng_size(VALUE obj)
 {
   gsl_rng *r = NULL;
   Data_Get_Struct(obj, gsl_rng, r);

--- a/ext/gsl_native/rng.c
+++ b/ext/gsl_native/rng.c
@@ -558,6 +558,7 @@ static VALUE rb_gsl_rng_memcpy(VALUE obj, VALUE dst, VALUE org)
 void Init_gsl_rng(VALUE module)
 {
   cgsl_rng = rb_define_class_under(module, "Rng", cGSL_Object);
+  rb_undef_alloc_func(cgsl_rng);
 
   rb_gsl_rng_define_const_type(module);
 

--- a/ext/gsl_native/root.c
+++ b/ext/gsl_native/root.c
@@ -361,6 +361,7 @@ void Init_gsl_root(VALUE module)
   mgsl_root = rb_define_module_under(module, "Root");
 
   cgsl_fsolver = rb_define_class_under(mgsl_root, "FSolver", cGSL_Object);
+  rb_undef_alloc_func(cgsl_fsolver);
   rb_define_singleton_method(cgsl_fsolver, "alloc", rb_gsl_fsolver_new, 1);
 
   rb_define_method(cgsl_fsolver, "set", rb_gsl_fsolver_set, 3);
@@ -380,6 +381,7 @@ void Init_gsl_root(VALUE module)
                              rb_gsl_root_test_residual, 2);
 
   cgsl_fdfsolver = rb_define_class_under(mgsl_root, "FdfSolver", cGSL_Object);
+  rb_undef_alloc_func(cgsl_fdfsolver);
   rb_define_singleton_method(cgsl_fdfsolver, "alloc", rb_gsl_fdfsolver_new, 1);
 
   rb_define_method(cgsl_fdfsolver, "set", rb_gsl_fdfsolver_set, 2);

--- a/ext/gsl_native/sf.c
+++ b/ext/gsl_native/sf.c
@@ -1401,6 +1401,7 @@ void Init_gsl_sf(VALUE module)
 
   cgsl_sf_result = rb_define_class_under(mgsl_sf, "Result",
                                          cGSL_Object);
+  rb_undef_alloc_func(cgsl_sf_result);
   rb_define_singleton_method(cgsl_sf_result, "new", rb_gsl_sf_result_new,
                              0);
   rb_define_method(cgsl_sf_result, "print", rb_gsl_sf_result_print, 0);
@@ -1412,6 +1413,7 @@ void Init_gsl_sf(VALUE module)
 
   cgsl_sf_result_e10 = rb_define_class_under(mgsl_sf, "Result_e10",
                                              cGSL_Object);
+  rb_undef_alloc_func(cgsl_sf_result_e10);
   rb_define_singleton_method(cgsl_sf_result_e10, "new",
                              rb_gsl_sf_result_e10_new, 0);
   rb_define_method(cgsl_sf_result_e10, "val", rb_gsl_sf_result_e10_val, 0);

--- a/ext/gsl_native/sf_bessel.c
+++ b/ext/gsl_native/sf_bessel.c
@@ -847,7 +847,7 @@ void Init_gsl_sf_bessel(VALUE module)
   rb_define_module_function(mgsl_sf_bessel, "kl_scaled_array",  rb_gsl_sf_bessel_kl_scaled_array, 2);
   rb_define_module_function(mgsl_sf_bessel, "Jnu",  rb_gsl_sf_bessel_Jnu, 2);
   rb_define_module_function(mgsl_sf_bessel, "Jnu_e",  rb_gsl_sf_bessel_Jnu_e, 2);
-  rb_define_module_function(mgsl_sf_bessel, "sequence_Jnu_e",  rb_gsl_sf_bessel_sequence_Jnu_e, 3);
+  rb_define_module_function(mgsl_sf_bessel, "sequence_Jnu_e",  rb_gsl_sf_bessel_sequence_Jnu_e, -1);
 
   rb_define_module_function(mgsl_sf_bessel, "Ynu",  rb_gsl_sf_bessel_Ynu, 2);
   rb_define_module_function(mgsl_sf_bessel, "Ynu_e",  rb_gsl_sf_bessel_Ynu_e, 2);

--- a/ext/gsl_native/sf_ellint.c
+++ b/ext/gsl_native/sf_ellint.c
@@ -172,7 +172,7 @@ void Init_gsl_sf_ellint(VALUE module)
   rb_define_module_function(module, "ellint_P",  rb_gsl_sf_ellint_P, -1);
   rb_define_module_function(module, "ellint_P_e",  rb_gsl_sf_ellint_P_e, 4);
   rb_define_module_function(module, "ellint_D",  rb_gsl_sf_ellint_D, -1);
-  rb_define_module_function(module, "ellint_D_e",  rb_gsl_sf_ellint_D_e, 4);
+  rb_define_module_function(module, "ellint_D_e",  rb_gsl_sf_ellint_D_e, 3);
   rb_define_module_function(module, "ellint_RC",  rb_gsl_sf_ellint_RC, -1);
   rb_define_module_function(module, "ellint_RC_e",  rb_gsl_sf_ellint_RC_e, 3);
   rb_define_module_function(module, "ellint_RD",  rb_gsl_sf_ellint_RD, -1);
@@ -194,7 +194,7 @@ void Init_gsl_sf_ellint(VALUE module)
   rb_define_module_function(mgsl_sf_ellint, "P",  rb_gsl_sf_ellint_P, -1);
   rb_define_module_function(mgsl_sf_ellint, "P_e",  rb_gsl_sf_ellint_P_e, 4);
   rb_define_module_function(mgsl_sf_ellint, "D",  rb_gsl_sf_ellint_D, -1);
-  rb_define_module_function(mgsl_sf_ellint, "D_e",  rb_gsl_sf_ellint_D_e, 4);
+  rb_define_module_function(mgsl_sf_ellint, "D_e",  rb_gsl_sf_ellint_D_e, 3);
   rb_define_module_function(mgsl_sf_ellint, "RC",  rb_gsl_sf_ellint_RC, -1);
   rb_define_module_function(mgsl_sf_ellint, "RC_e",  rb_gsl_sf_ellint_RC_e, 3);
   rb_define_module_function(mgsl_sf_ellint, "RD",  rb_gsl_sf_ellint_RD, -1);

--- a/ext/gsl_native/sf_mathieu.c
+++ b/ext/gsl_native/sf_mathieu.c
@@ -147,9 +147,9 @@ static VALUE rb_gsl_sf_mathieu_a(VALUE module, VALUE order, VALUE qq)
   return sf_mathieu_eval(order, qq, gsl_sf_mathieu_a);
 #endif
 }
-static VALUE rb_gsl_sf_mathieu_a_array(VALUE module, int argc, VALUE *argv)
+static VALUE rb_gsl_sf_mathieu_a_array(VALUE module, VALUE argc, VALUE argv)
 {
-  return sf_mathieu_array_eval(argc, argv, gsl_sf_mathieu_a_array);
+  return sf_mathieu_array_eval((int)argc, &argv, gsl_sf_mathieu_a_array);
 }
 static VALUE rb_gsl_sf_mathieu_b_e(VALUE module, VALUE order, VALUE qq)
 {
@@ -167,9 +167,9 @@ static VALUE rb_gsl_sf_mathieu_b(VALUE module, VALUE order, VALUE qq)
   return sf_mathieu_eval(order, qq, gsl_sf_mathieu_b);
 #endif
 }
-static VALUE rb_gsl_sf_mathieu_b_array(VALUE module, int argc, VALUE *argv)
+static VALUE rb_gsl_sf_mathieu_b_array(VALUE module, VALUE argc, VALUE argv)
 {
-  return sf_mathieu_array_eval(argc, argv, gsl_sf_mathieu_b_array);
+  return sf_mathieu_array_eval((int)argc, &argv, gsl_sf_mathieu_b_array);
 }
 static VALUE rb_gsl_sf_mathieu_ce_e(VALUE module, VALUE order, VALUE qq, VALUE zz)
 {
@@ -187,9 +187,9 @@ static VALUE rb_gsl_sf_mathieu_ce(VALUE module, VALUE order, VALUE qq, VALUE zz)
   return sf_mathieu_eval_int_double2(order, qq, zz, gsl_sf_mathieu_ce);
 #endif
 }
-static VALUE rb_gsl_sf_mathieu_ce_array(VALUE module, int argc, VALUE *argv)
+static VALUE rb_gsl_sf_mathieu_ce_array(VALUE module, VALUE argc, VALUE argv)
 {
-  return sf_mathieu_array_eval2(argc, argv, gsl_sf_mathieu_ce_array);
+  return sf_mathieu_array_eval2((int)argc, &argv, gsl_sf_mathieu_ce_array);
 }
 static VALUE rb_gsl_sf_mathieu_se_e(VALUE module, VALUE order, VALUE qq, VALUE zz)
 {
@@ -207,9 +207,9 @@ static VALUE rb_gsl_sf_mathieu_se(VALUE module, VALUE order, VALUE qq, VALUE zz)
   return sf_mathieu_eval_int_double2(order, qq, zz, gsl_sf_mathieu_se);
 #endif
 }
-static VALUE rb_gsl_sf_mathieu_se_array(VALUE module, int argc, VALUE *argv)
+static VALUE rb_gsl_sf_mathieu_se_array(VALUE module, VALUE argc, VALUE argv)
 {
-  return sf_mathieu_array_eval2(argc, argv, gsl_sf_mathieu_se_array);
+  return sf_mathieu_array_eval2((int)argc, &argv, gsl_sf_mathieu_se_array);
 }
 
 /*****/
@@ -229,9 +229,9 @@ static VALUE rb_gsl_sf_mathieu_Mc(VALUE module, VALUE n1, VALUE n2, VALUE q, VAL
   return sf_mathieu_eval2(n1, n2, q, x, gsl_sf_mathieu_Mc);
 #endif
 }
-static VALUE rb_gsl_sf_mathieu_Mc_array(VALUE module, int argc, VALUE *argv)
+static VALUE rb_gsl_sf_mathieu_Mc_array(VALUE module, VALUE argc, VALUE argv)
 {
-  return sf_mathieu_array_eval3(argc, argv, gsl_sf_mathieu_Mc_array);
+  return sf_mathieu_array_eval3((int)argc, &argv, gsl_sf_mathieu_Mc_array);
 }
 static VALUE rb_gsl_sf_mathieu_Ms_e(VALUE module, VALUE n1, VALUE n2, VALUE q, VALUE x)
 {
@@ -249,9 +249,9 @@ static VALUE rb_gsl_sf_mathieu_Ms(VALUE module, VALUE n1, VALUE n2, VALUE q, VAL
   return sf_mathieu_eval2(n1, n2, q, x, gsl_sf_mathieu_Ms);
 #endif
 }
-static VALUE rb_gsl_sf_mathieu_Ms_array(VALUE module, int argc, VALUE *argv)
+static VALUE rb_gsl_sf_mathieu_Ms_array(VALUE module, VALUE argc, VALUE argv)
 {
-  return sf_mathieu_array_eval3(argc, argv, gsl_sf_mathieu_Ms_array);
+  return sf_mathieu_array_eval3((int)argc, &argv, gsl_sf_mathieu_Ms_array);
 }
 /*****/
 void Init_sf_mathieu(VALUE module)
@@ -264,20 +264,20 @@ void Init_sf_mathieu(VALUE module)
 
   rb_define_module_function(module, "mathieu_a", rb_gsl_sf_mathieu_a, 2);
   rb_define_module_function(module, "mathieu_a_e", rb_gsl_sf_mathieu_a_e, 2);
-  rb_define_module_function(module, "mathieu_a_array", rb_gsl_sf_mathieu_a_array, -1);
+  rb_define_module_function(module, "mathieu_a_array", rb_gsl_sf_mathieu_a_array, 2);
   rb_define_module_function(module, "mathieu_b", rb_gsl_sf_mathieu_b, 2);
   rb_define_module_function(module, "mathieu_b_e", rb_gsl_sf_mathieu_b_e, 2);
-  rb_define_module_function(module, "mathieu_b_array", rb_gsl_sf_mathieu_b_array, -1);
+  rb_define_module_function(module, "mathieu_b_array", rb_gsl_sf_mathieu_b_array, 2);
   rb_define_module_function(module, "mathieu_ce", rb_gsl_sf_mathieu_ce, 3);
   rb_define_module_function(module, "mathieu_ce_e", rb_gsl_sf_mathieu_ce_e, 3);
-  rb_define_module_function(module, "mathieu_ce_array", rb_gsl_sf_mathieu_ce_array, -1);
+  rb_define_module_function(module, "mathieu_ce_array", rb_gsl_sf_mathieu_ce_array, 2);
   rb_define_module_function(module, "mathieu_se", rb_gsl_sf_mathieu_se, 3);
   rb_define_module_function(module, "mathieu_se_e", rb_gsl_sf_mathieu_se_e, 3);
-  rb_define_module_function(module, "mathieu_se_array", rb_gsl_sf_mathieu_se_array, -1);
+  rb_define_module_function(module, "mathieu_se_array", rb_gsl_sf_mathieu_se_array, 2);
   rb_define_module_function(module, "mathieu_Mc", rb_gsl_sf_mathieu_Mc, 4);
   rb_define_module_function(module, "mathieu_Mc_e", rb_gsl_sf_mathieu_Mc_e, 4);
-  rb_define_module_function(module, "mathieu_Mc_array", rb_gsl_sf_mathieu_Mc_array, -1);
+  rb_define_module_function(module, "mathieu_Mc_array", rb_gsl_sf_mathieu_Mc_array, 2);
   rb_define_module_function(module, "mathieu_Ms", rb_gsl_sf_mathieu_Ms, 4);
   rb_define_module_function(module, "mathieu_Ms_e", rb_gsl_sf_mathieu_Ms_e, 4);
-  rb_define_module_function(module, "mathieu_Ms_array", rb_gsl_sf_mathieu_Ms_array, -1);
+  rb_define_module_function(module, "mathieu_Ms_array", rb_gsl_sf_mathieu_Ms_array, 2);
 }

--- a/ext/gsl_native/sf_mathieu.c
+++ b/ext/gsl_native/sf_mathieu.c
@@ -260,6 +260,7 @@ void Init_sf_mathieu(VALUE module)
 
   mMathieu = rb_define_module_under(module, "Mathieu");
   cWorkspace = rb_define_class_under(mMathieu, "Workspace", cGSL_Object);
+  rb_undef_alloc_func(cWorkspace);
   rb_define_singleton_method(cWorkspace, "alloc", rb_gsl_sf_mathieu_alloc, 2);
 
   rb_define_module_function(module, "mathieu_a", rb_gsl_sf_mathieu_a, 2);

--- a/ext/gsl_native/siman.c
+++ b/ext/gsl_native/siman.c
@@ -654,11 +654,17 @@ void Init_gsl_siman(VALUE module)
   mgsl_siman = rb_define_module_under(module, "Siman");
 
   cgsl_siman_Efunc = rb_define_class_under(mgsl_siman, "Efunc", cGSL_Object);
+  rb_undef_alloc_func(cgsl_siman_Efunc);
   cgsl_siman_step = rb_define_class_under(mgsl_siman, "Step", cGSL_Object);
+  rb_undef_alloc_func(cgsl_siman_step);
   cgsl_siman_metric = rb_define_class_under(mgsl_siman, "Metric", cGSL_Object);
+  rb_undef_alloc_func(cgsl_siman_metric);
   cgsl_siman_print = rb_define_class_under(mgsl_siman, "Print", cGSL_Object);
+  rb_undef_alloc_func(cgsl_siman_print);
   cgsl_siman_params = rb_define_class_under(mgsl_siman, "Params", cGSL_Object);
+  rb_undef_alloc_func(cgsl_siman_params);
   cgsl_siman_solver = rb_define_class_under(mgsl_siman, "Solver", cGSL_Object);
+  rb_undef_alloc_func(cgsl_siman_solver);
 
   /***** Efunc *****/
   rb_define_singleton_method(cgsl_siman_Efunc, "alloc", rb_gsl_siman_Efunc_new, -1);

--- a/ext/gsl_native/spline.c
+++ b/ext/gsl_native/spline.c
@@ -398,7 +398,7 @@ void Init_gsl_spline(VALUE module)
   rb_define_alias(cgsl_spline, "deriv_e", "eval_deriv_e");
   rb_define_method(cgsl_spline, "eval_deriv2_e", rb_gsl_spline_eval_deriv2_e, 1);
   rb_define_alias(cgsl_spline, "deri2v_e", "eval_deriv2_e");
-  rb_define_method(cgsl_spline, "eval_integ_e", rb_gsl_spline_eval_integ_e, 1);
+  rb_define_method(cgsl_spline, "eval_integ_e", rb_gsl_spline_eval_integ_e, 2);
   rb_define_alias(cgsl_spline, "integ_e", "eval_integ_e");
 
   rb_define_method(cgsl_spline, "info", rb_gsl_spline_info, 0);

--- a/ext/gsl_native/spline.c
+++ b/ext/gsl_native/spline.c
@@ -371,6 +371,7 @@ void Init_gsl_spline(VALUE module)
   VALUE cgsl_spline;
 
   cgsl_spline = rb_define_class_under(module, "Spline", cGSL_Object);
+  rb_undef_alloc_func(cgsl_spline);
 
   rb_define_singleton_method(cgsl_spline, "alloc", rb_gsl_spline_new, -1);
 

--- a/ext/gsl_native/spline2d.c
+++ b/ext/gsl_native/spline2d.c
@@ -83,9 +83,9 @@ static VALUE rb_gsl_spline2d_accel(VALUE self)
 }
 
 static VALUE rb_gsl_spline2d_evaluate(VALUE self, VALUE xx, VALUE yy,
-  double (*eval)(const gsl_spline2d *, double, double, gsl_interp_accel *, 
+  double (*eval)(const gsl_spline2d *, double, double, gsl_interp_accel *,
     gsl_interp_accel *))
-{ 
+{
   VALUE is_swapped = rb_cvar_get(CLASS_OF(self), rb_intern("@@swapped"));
   VALUE temp;
 
@@ -94,7 +94,7 @@ static VALUE rb_gsl_spline2d_evaluate(VALUE self, VALUE xx, VALUE yy,
     xx = yy;
     yy = temp;
   }
-  
+
   rb_gsl_spline2d *rgs = NULL;
   gsl_vector *vx = NULL, *vy = NULL, *vnew = NULL;
   gsl_matrix *mx = NULL, *my = NULL, *mnew = NULL;
@@ -143,7 +143,7 @@ static VALUE rb_gsl_spline2d_evaluate(VALUE self, VALUE xx, VALUE yy,
       vnew = gsl_vector_alloc(vx->size);
 
       for (i = 0; i < vx->size; i++) {
-        val = (*eval)(rgs->s, gsl_vector_get(vx, i), gsl_vector_get(vy, i), 
+        val = (*eval)(rgs->s, gsl_vector_get(vx, i), gsl_vector_get(vy, i),
           rgs->xacc, rgs->yacc);
         gsl_vector_set(vnew, i, val);
       }
@@ -171,7 +171,7 @@ static VALUE rb_gsl_spline2d_evaluate(VALUE self, VALUE xx, VALUE yy,
 }
 
 static VALUE rb_gsl_spline2d_eval(VALUE self, VALUE xx, VALUE yy)
-{ 
+{
   return rb_gsl_spline2d_evaluate(self, xx, yy, gsl_spline2d_eval);
 }
 
@@ -197,6 +197,7 @@ void Init_gsl_spline2d(VALUE module)
   VALUE cgsl_spline2d;
 
   cgsl_spline2d = rb_define_class_under(module, "Spline2d", cGSL_Object);
+  rb_undef_alloc_func(cgsl_spline2d);
 
   rb_define_singleton_method(cgsl_spline2d, "alloc", rb_gsl_spline2d_alloc, -1);
 

--- a/ext/gsl_native/stats.c
+++ b/ext/gsl_native/stats.c
@@ -706,20 +706,20 @@ void Init_gsl_stats(VALUE module)
 
   /*****/
 
-  rb_define_singleton_method(mgsl_stats, "wmean", rb_gsl_stats_wmean2, -1);
-  rb_define_singleton_method(mgsl_stats, "wvariance", rb_gsl_stats_wvariance2, -1);
-  rb_define_singleton_method(mgsl_stats, "wvariance_m", rb_gsl_stats_wvariance_m2, -1);
-  rb_define_singleton_method(mgsl_stats, "wsd", rb_gsl_stats_wsd2, -1);
-  rb_define_singleton_method(mgsl_stats, "wsd_m", rb_gsl_stats_wsd_m2, -1);
+  rb_define_singleton_method(mgsl_stats, "wmean", rb_gsl_stats_wmean2, 2);
+  rb_define_singleton_method(mgsl_stats, "wvariance", rb_gsl_stats_wvariance2, 2);
+  rb_define_singleton_method(mgsl_stats, "wvariance_m", rb_gsl_stats_wvariance_m2, 3);
+  rb_define_singleton_method(mgsl_stats, "wsd", rb_gsl_stats_wsd2, 2);
+  rb_define_singleton_method(mgsl_stats, "wsd_m", rb_gsl_stats_wsd_m2, 3);
   rb_define_singleton_method(mgsl_stats, "wvariance_with_fixed_mean",
-                             rb_gsl_stats_wvariance_with_fixed_mean2, -1);
+                             rb_gsl_stats_wvariance_with_fixed_mean2, 3);
   rb_define_singleton_method(mgsl_stats, "wsd_with_fixed_mean",
-                             rb_gsl_stats_wsd_with_fixed_mean2, -1);
-  rb_define_singleton_method(mgsl_stats, "wabsdev", rb_gsl_stats_wabsdev2, -1);
-  rb_define_singleton_method(mgsl_stats, "wabsdev_m", rb_gsl_stats_wabsdev_m2, -1);
-  rb_define_singleton_method(mgsl_stats, "wskew", rb_gsl_stats_wskew2, -1);
+                             rb_gsl_stats_wsd_with_fixed_mean2, 3);
+  rb_define_singleton_method(mgsl_stats, "wabsdev", rb_gsl_stats_wabsdev2, 2);
+  rb_define_singleton_method(mgsl_stats, "wabsdev_m", rb_gsl_stats_wabsdev_m2, 3);
+  rb_define_singleton_method(mgsl_stats, "wskew", rb_gsl_stats_wskew2, 2);
   rb_define_singleton_method(mgsl_stats, "wskew_m_sd", rb_gsl_stats_wskew_m2, 4);
-  rb_define_singleton_method(mgsl_stats, "wkurtosis", rb_gsl_stats_wkurtosis2, -1);
+  rb_define_singleton_method(mgsl_stats, "wkurtosis", rb_gsl_stats_wkurtosis2, 2);
   rb_define_singleton_method(mgsl_stats, "wkurtosis_m_sd", rb_gsl_stats_wkurtosis_m2, 4);
 
   /*****/
@@ -747,12 +747,12 @@ void Init_gsl_stats(VALUE module)
   rb_define_alias(cgsl_vector, "wabsdev_m", "stats_wabsdev_m");
   rb_define_method(cgsl_vector, "stats_wskew", rb_gsl_stats_wskew, -1);
   rb_define_alias(cgsl_vector, "wskew", "stats_wskew");
-  rb_define_method(cgsl_vector, "stats_wskew_m_sd", rb_gsl_stats_wskew_m_sd, 2);
+  rb_define_method(cgsl_vector, "stats_wskew_m_sd", rb_gsl_stats_wskew_m_sd, 3);
   rb_define_alias(cgsl_vector, "wskew_m_sd", "stats_wskew_m_sd");
   rb_define_method(cgsl_vector, "stats_wkurtosis", rb_gsl_stats_wkurtosis, -1);
   rb_define_alias(cgsl_vector, "wkurtosis", "stats_wkurtosis");
   rb_define_method(cgsl_vector, "stats_wkurtosis_m_sd",
-                   rb_gsl_stats_wkurtosis_m_sd, 2);
+                   rb_gsl_stats_wkurtosis_m_sd, 3);
   rb_define_alias(cgsl_vector, "wkurtosis_m_sd", "stats_wkurtosis_m_sd");
 
   /*****/

--- a/ext/gsl_native/sum.c
+++ b/ext/gsl_native/sum.c
@@ -127,9 +127,10 @@ void Init_gsl_sum(VALUE module)
   mgsl_sum = rb_define_module_under(module, "Sum");
   cgsl_sum_levin_u = rb_define_class_under(mgsl_sum,
                                            "Levin_u", cGSL_Object);
+  rb_undef_alloc_func(cgsl_sum_levin_u);
   cgsl_sum_levin_utrunc = rb_define_class_under(mgsl_sum,
                                                 "Levin_utrunc", cGSL_Object);
-
+  rb_undef_alloc_func(cgsl_sum_levin_utrunc);
   rb_define_singleton_method(cgsl_sum_levin_u, "new", rb_gsl_sum_levin_u_new, 1);
   rb_define_singleton_method(cgsl_sum_levin_u, "alloc", rb_gsl_sum_levin_u_new, 1);
   rb_define_singleton_method(cgsl_sum_levin_utrunc, "new",

--- a/ext/gsl_native/tamu_anova.c
+++ b/ext/gsl_native/tamu_anova.c
@@ -29,10 +29,10 @@ VALUE rb_tamu_anova_alloc(int argc, VALUE *argv, VALUE klass)
   return Data_Wrap_Struct(klass, 0, free, table);
 }
 
-VALUE rb_tamu_anova_printtable(VALUE *vTable)
+VALUE rb_tamu_anova_printtable(VALUE vTable)
 {
   struct tamu_anova_table *table;
-  Data_Get_Struct(*vTable, struct tamu_anova_table, table);
+  Data_Get_Struct(vTable, struct tamu_anova_table, table);
   tamu_anova_printtable(*table);
   return Qtrue;
 }

--- a/ext/gsl_native/vector_complex.c
+++ b/ext/gsl_native/vector_complex.c
@@ -1829,7 +1829,7 @@ static VALUE rb_gsl_vector_complex_block(VALUE obj)
   return Data_Wrap_Struct(cgsl_block_complex, 0, NULL, v->block);
 }
 
-static VALUE rb_gsl_vector_complex_indgen_bang(int argc, VALUE *argv[], VALUE obj)
+static VALUE rb_gsl_vector_complex_indgen_bang(int argc, VALUE argv[], VALUE obj)
 {
   gsl_vector_complex *v = NULL;
   double start = 0.0, step = 1.0, x;
@@ -2112,7 +2112,7 @@ void Init_gsl_vector_complex(VALUE module)
   rb_define_method(cgsl_vector_complex, "isnull", rb_gsl_vector_complex_isnull, 0);
 
   rb_define_method(cgsl_vector_complex, "matrix_view", rb_gsl_vector_complex_matrix_view, -1);
-  rb_define_method(cgsl_vector_complex, "matrix_view_with_tda", rb_gsl_vector_complex_matrix_view_with_tda, -1);
+  rb_define_method(cgsl_vector_complex, "matrix_view_with_tda", rb_gsl_vector_complex_matrix_view_with_tda, 3);
 
   rb_define_method(cgsl_vector_complex, "trans", rb_gsl_vector_complex_trans, 0);
   rb_define_alias(cgsl_vector_complex, "transpose", "trans");
@@ -2238,4 +2238,3 @@ void Init_gsl_vector_complex(VALUE module)
   rb_define_method(cgsl_vector_complex, "not_equal?", rb_gsl_vector_complex_not_equal, -1);
   rb_define_alias(cgsl_vector_complex, "!=", "not_equal?");
 }
-

--- a/ext/gsl_native/wavelet.c
+++ b/ext/gsl_native/wavelet.c
@@ -738,7 +738,9 @@ void Init_wavelet(VALUE module)
   VALUE cgsl_wavelet2d;
 
   cgsl_wavelet = rb_define_class_under(module, "Wavelet", cGSL_Object);
+  rb_undef_alloc_func(cgsl_wavelet);
   cgsl_wavelet2d = rb_define_class_under(module, "Wavelet2d", cgsl_wavelet);
+  rb_undef_alloc_func(cgsl_wavelet2d);
 
   rb_define_singleton_method(cgsl_wavelet, "alloc", rb_gsl_wavelet_new, 2);
 
@@ -746,6 +748,7 @@ void Init_wavelet(VALUE module)
   rb_define_method(cgsl_wavelet, "name", rb_gsl_wavelet_name, 0);
 
   cgsl_wavelet_workspace = rb_define_class_under(cgsl_wavelet, "Workspace", cGSL_Object);
+  rb_undef_alloc_func(cgsl_wavelet_workspace);
   rb_define_singleton_method(cgsl_wavelet_workspace, "alloc",
                              rb_gsl_wavelet_workspace_new, 1);
 
@@ -920,4 +923,3 @@ void Init_wavelet(VALUE module)
 
 #undef CHECK_WAVELET
 #undef CHECK_WORKSPACE
-


### PR DESCRIPTION
I have made it possible to build with Ruby ver. 3 and gcc-14. It now passes the current tests, but I'm not  confident about the fixes. Please review...