### PR TITLE
fix: Ruby 3.4 compatibility for function pointer types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ extconf.h
 Gemfile.lock
 *~
 *.gem
+ext/gsl_native/gsl_config.h

--- a/ext/gsl_native/blas2.c
+++ b/ext/gsl_native/blas2.c
@@ -1081,8 +1081,8 @@ void Init_gsl_blas2(VALUE module)
   rb_define_module_function(module, "zher!", rb_gsl_blas_zher, 4);
   rb_define_module_function(module, "zher", rb_gsl_blas_zher_a, 4);
 
-  rb_define_module_function(module, "dsyr2!", rb_gsl_blas_dsyr2, 4);
-  rb_define_module_function(module, "dsyr2", rb_gsl_blas_dsyr2_a, 4);
-  rb_define_module_function(module, "zher2!", rb_gsl_blas_zher2, 4);
-  rb_define_module_function(module, "zher2", rb_gsl_blas_zher2_a, 4);
+  rb_define_module_function(module, "dsyr2!", rb_gsl_blas_dsyr2, 5);
+  rb_define_module_function(module, "dsyr2", rb_gsl_blas_dsyr2_a, 5);
+  rb_define_module_function(module, "zher2!", rb_gsl_blas_zher2, 5);
+  rb_define_module_function(module, "zher2", rb_gsl_blas_zher2_a, 5);
 }

--- a/ext/gsl_native/bspline.c
+++ b/ext/gsl_native/bspline.c
@@ -98,7 +98,7 @@ static VALUE rb_gsl_bspline_eval(int argc, VALUE *argv, VALUE obj)
     break;
   case 1:
     x = NUM2DBL(argv[0]);
-    B = gsl_vector_alloc(w->nbreak+w->k-2);
+    B = gsl_vector_alloc(gsl_bspline_ncontrol(w));
     vB = Data_Wrap_Struct(cgsl_vector, 0, gsl_vector_free, B);
     break;
   default:

--- a/ext/gsl_native/gsl.c
+++ b/ext/gsl_native/gsl.c
@@ -27,8 +27,9 @@ static VALUE rb_gsl_object_inspect(VALUE obj)
   return rb_str_new2(buf);
 }
 
-static VALUE rb_gsl_call_rescue(VALUE obj)
+static VALUE rb_gsl_call_rescue(VALUE obj, VALUE exc)
 {
+  (void)exc;
   return Qfalse;
 }
 

--- a/ext/gsl_native/histogram2d.c
+++ b/ext/gsl_native/histogram2d.c
@@ -474,7 +474,7 @@ static VALUE rb_gsl_histogram2d_add(VALUE obj, VALUE hh2)
     Need_Float(hh2);
     gsl_histogram2d_shift(hnew, NUM2DBL(hh2));
   }
-  return Data_Wrap_Struct(CLASS_OF(h1), 0, gsl_histogram2d_free, hnew);
+  return Data_Wrap_Struct(CLASS_OF(obj), 0, gsl_histogram2d_free, hnew);
 }
 
 static VALUE rb_gsl_histogram2d_sub(VALUE obj, VALUE hh2)
@@ -489,7 +489,7 @@ static VALUE rb_gsl_histogram2d_sub(VALUE obj, VALUE hh2)
     Need_Float(hh2);
     gsl_histogram2d_shift(hnew, -NUM2DBL(hh2));
   }
-  return Data_Wrap_Struct(CLASS_OF(h1), 0, gsl_histogram2d_free, hnew);
+  return Data_Wrap_Struct(CLASS_OF(obj), 0, gsl_histogram2d_free, hnew);
 }
 
 static VALUE rb_gsl_histogram2d_mul(VALUE obj, VALUE hh2)
@@ -504,7 +504,7 @@ static VALUE rb_gsl_histogram2d_mul(VALUE obj, VALUE hh2)
     Need_Float(hh2);
     gsl_histogram2d_scale(hnew, NUM2DBL(hh2));
   }
-  return Data_Wrap_Struct(CLASS_OF(h1), 0, gsl_histogram2d_free, hnew);
+  return Data_Wrap_Struct(CLASS_OF(obj), 0, gsl_histogram2d_free, hnew);
 }
 
 static VALUE rb_gsl_histogram2d_div(VALUE obj, VALUE hh2)
@@ -519,7 +519,7 @@ static VALUE rb_gsl_histogram2d_div(VALUE obj, VALUE hh2)
     Need_Float(hh2);
     gsl_histogram2d_scale(hnew, 1.0/NUM2DBL(hh2));
   }
-  return Data_Wrap_Struct(CLASS_OF(h1), 0, gsl_histogram2d_free, hnew);
+  return Data_Wrap_Struct(CLASS_OF(obj), 0, gsl_histogram2d_free, hnew);
 }
 
 static VALUE rb_gsl_histogram2d_scale2(VALUE obj, VALUE val)
@@ -529,7 +529,7 @@ static VALUE rb_gsl_histogram2d_scale2(VALUE obj, VALUE val)
   Data_Get_Struct(obj, gsl_histogram2d, h1);
   hnew = gsl_histogram2d_clone(h1);
   gsl_histogram2d_scale(hnew, NUM2DBL(val));
-  return Data_Wrap_Struct(CLASS_OF(h1), 0, gsl_histogram2d_free, hnew);
+  return Data_Wrap_Struct(CLASS_OF(obj), 0, gsl_histogram2d_free, hnew);
 }
 
 static VALUE rb_gsl_histogram2d_shift2(VALUE obj, VALUE val)
@@ -539,7 +539,7 @@ static VALUE rb_gsl_histogram2d_shift2(VALUE obj, VALUE val)
   Data_Get_Struct(obj, gsl_histogram2d, h1);
   hnew = gsl_histogram2d_clone(h1);
   gsl_histogram2d_shift(hnew, NUM2DBL(val));
-  return Data_Wrap_Struct(CLASS_OF(h1), 0, gsl_histogram2d_free, hnew);
+  return Data_Wrap_Struct(CLASS_OF(obj), 0, gsl_histogram2d_free, hnew);
 }
 
 static VALUE rb_gsl_histogram2d_fwrite(VALUE obj, VALUE io)
@@ -1006,7 +1006,7 @@ void Init_gsl_histogram2d(VALUE module)
   rb_define_method(cgsl_histogram2d, "fwrite2",  rb_gsl_histogram2d_fwrite2, 1);
   rb_define_method(cgsl_histogram2d, "fread2",  rb_gsl_histogram2d_fread2, 1);
   rb_define_method(cgsl_histogram2d, "fprintf",  rb_gsl_histogram2d_fprintf, -1);
-  rb_define_method(cgsl_histogram2d, "fscanf",  rb_gsl_histogram2d_fscanf, 3);
+  rb_define_method(cgsl_histogram2d, "fscanf",  rb_gsl_histogram2d_fscanf, 1);
 
   cgsl_histogram2d_pdf = rb_define_class_under(cgsl_histogram2d, "Pdf", cGSL_Object);
 

--- a/ext/gsl_native/ieee.c
+++ b/ext/gsl_native/ieee.c
@@ -81,8 +81,8 @@ void Init_gsl_ieee(VALUE module)
   rb_define_singleton_method(mgsl_ieee, "fprintf",
                              rb_gsl_ieee_fprintf_double, -1);
   rb_define_singleton_method(mgsl_ieee, "printf",
-                             rb_gsl_ieee_printf_double, -1);
+                             rb_gsl_ieee_printf_double, 1);
   rb_define_singleton_method(mgsl_ieee, "printf_double",
-                             rb_gsl_ieee_printf_double, -1);
+                             rb_gsl_ieee_printf_double, 1);
 
 }

--- a/ext/gsl_native/linalg.c
+++ b/ext/gsl_native/linalg.c
@@ -1696,8 +1696,7 @@ static VALUE rb_gsl_linalg_R_solve(int argc, VALUE *argv, VALUE obj)
 }
 
 /* singleton */
-static VALUE rb_gsl_linalg_QR_QRsolve(int argc, VALUE *argv, VALUE obj,
-                                      int flag)
+static VALUE rb_gsl_linalg_QR_QRsolve(int argc, VALUE *argv, VALUE obj)
 {
   return rb_gsl_linalg_QRLQ_QRLQsolve(argc, argv, obj, LINALG_QR_DECOMP);
 }
@@ -1718,8 +1717,7 @@ static VALUE rb_gsl_linalg_L_solve(int argc, VALUE *argv, VALUE obj)
 }
 
 /* singleton */
-static VALUE rb_gsl_linalg_LQ_LQsolve(int argc, VALUE *argv, VALUE obj,
-                                      int flag)
+static VALUE rb_gsl_linalg_LQ_LQsolve(int argc, VALUE *argv, VALUE obj)
 {
   return rb_gsl_linalg_QRLQ_QRLQsolve(argc, argv, obj, LINALG_LQ_DECOMP);
 }
@@ -4049,7 +4047,7 @@ void Init_gsl_linalg(VALUE module)
   rb_define_method(cgsl_matrix_QR, "Rsolve", rb_gsl_linalg_QR_Rsolve, -1);
 
   rb_define_module_function(mgsl_linalg_QR, "Rsvx", rb_gsl_linalg_QR_Rsvx, -1);
-  rb_define_method(cgsl_matrix_QR, "Rsvx", rb_gsl_linalg_QR_Rsvx, 1);
+  rb_define_method(cgsl_matrix_QR, "Rsvx", rb_gsl_linalg_QR_Rsvx, -1);
 
   rb_define_module_function(mgsl_linalg_QR, "unpack", rb_gsl_linalg_QR_unpack, -1);
   rb_define_method(cgsl_matrix_QR, "unpack", rb_gsl_linalg_QR_unpack, -1);
@@ -4250,7 +4248,7 @@ void Init_gsl_linalg(VALUE module)
   rb_define_method(cgsl_matrix_LQ, "Lsolve_T", rb_gsl_linalg_LQ_Lsolve, -1);
 
   rb_define_module_function(mgsl_linalg_LQ, "Lsvx_T", rb_gsl_linalg_LQ_Lsvx, -1);
-  rb_define_method(cgsl_matrix_LQ, "Lsvx_T", rb_gsl_linalg_LQ_Lsvx, 1);
+  rb_define_method(cgsl_matrix_LQ, "Lsvx_T", rb_gsl_linalg_LQ_Lsvx, -1);
 
   rb_define_module_function(mgsl_linalg_LQ, "unpack", rb_gsl_linalg_LQ_unpack, -1);
   rb_define_method(cgsl_matrix_LQ, "unpack", rb_gsl_linalg_LQ_unpack, -1);

--- a/ext/gsl_native/matrix_complex.c
+++ b/ext/gsl_native/matrix_complex.c
@@ -1094,17 +1094,7 @@ static VALUE rb_gsl_matrix_complex_imag(VALUE obj)
   return Data_Wrap_Struct(cgsl_matrix, 0, gsl_matrix_free, m);
 }
 
-static void gsl_matrix_complex_conjugate(gsl_matrix_complex *cm)
-{
-  gsl_complex z;
-  size_t i, j;
-  for (i = 0; i < cm->size1; i++) {
-    for (j = 0; j < cm->size2; j++) {
-      z = gsl_matrix_complex_get(cm, i, j);
-      gsl_matrix_complex_set(cm, i, j, gsl_complex_conjugate(z));
-    }
-  }
-}
+/* gsl_matrix_complex_conjugate is now provided by GSL 2.8+ */
 
 static void gsl_matrix_complex_conjugate2(gsl_matrix_complex *cmnew, gsl_matrix_complex *cm)
 {
@@ -1424,7 +1414,7 @@ static VALUE rb_gsl_matrix_complex_arccoth(VALUE obj)
   return rb_gsl_matrix_complex_XXX_complex(obj, gsl_complex_arccoth);
 }
 
-static VALUE rb_gsl_matrix_complex_indgen_bang(int argc, VALUE *argv[], VALUE obj)
+static VALUE rb_gsl_matrix_complex_indgen_bang(int argc, VALUE *argv, VALUE obj)
 {
   gsl_matrix_complex *m = NULL;
   double start = 0, step = 1, x;

--- a/ext/gsl_native/monte.c
+++ b/ext/gsl_native/monte.c
@@ -852,7 +852,7 @@ void Init_gsl_monte(VALUE module)
   rb_define_singleton_method(cgsl_monte_function, "alloc", rb_gsl_monte_function_new, -1);
 
   rb_define_method(cgsl_monte_function, "proc", rb_gsl_monte_function_proc, 0);
-  rb_define_method(cgsl_monte_function, "eval", rb_gsl_monte_function_eval, 0);
+  rb_define_method(cgsl_monte_function, "eval", rb_gsl_monte_function_eval, 1);
   rb_define_alias(cgsl_monte_function, "call", "eval");
   rb_define_method(cgsl_monte_function, "params", rb_gsl_monte_function_params, 0);
   rb_define_method(cgsl_monte_function, "set", rb_gsl_monte_function_set_f, -1);

--- a/ext/gsl_native/multiroots.c
+++ b/ext/gsl_native/multiroots.c
@@ -99,7 +99,7 @@ static void gsl_multiroot_function_mark(gsl_multiroot_function *f)
   size_t i;
   rb_gc_mark((VALUE) f->params);
   //  for (i = 0; i < RARRAY(f->params)->len; i++)
-  for (i = 0; (int) i < RARRAY_LEN(f->params); i++)
+  for (i = 0; (int) i < RARRAY_LEN((VALUE) f->params); i++)
     rb_gc_mark(rb_ary_entry((VALUE) f->params, i));
 }
 
@@ -236,7 +236,7 @@ static void gsl_multiroot_function_fdf_mark(gsl_multiroot_function_fdf *f)
   size_t i;
   rb_gc_mark((VALUE) f->params);
   //  for (i = 0; i < RARRAY(f->params)->len; i++)
-  for (i = 0; (int) i < RARRAY_LEN(f->params); i++)
+  for (i = 0; (int) i < RARRAY_LEN((VALUE) f->params); i++)
     rb_gc_mark(rb_ary_entry((VALUE) f->params, i));
 }
 

--- a/ext/gsl_native/ntuple.c
+++ b/ext/gsl_native/ntuple.c
@@ -434,9 +434,9 @@ void Init_gsl_ntuple(VALUE module)
   rb_define_singleton_method(cgsl_ntuple, "create", rb_gsl_ntuple_new, -1);
   rb_define_singleton_method(cgsl_ntuple, "alloc", rb_gsl_ntuple_new, -1);
   rb_define_singleton_method(cgsl_ntuple, "open", rb_gsl_ntuple_open, -1);
-  rb_define_singleton_method(cgsl_ntuple, "close", rb_gsl_ntuple_close, 0);
+  rb_define_singleton_method(cgsl_ntuple, "close", rb_gsl_ntuple_close, 1);
 
-  rb_define_method(cgsl_ntuple, "size", rb_gsl_ntuple_size, 0);
+  rb_define_method(cgsl_ntuple, "size", rb_gsl_ntuple_size, 1);
   rb_define_method(cgsl_ntuple, "write", rb_gsl_ntuple_write, 0);
   rb_define_method(cgsl_ntuple, "bookdata", rb_gsl_ntuple_bookdata, 0);
 

--- a/ext/gsl_native/odeiv.c
+++ b/ext/gsl_native/odeiv.c
@@ -882,7 +882,7 @@ void Init_gsl_odeiv(VALUE module)
   rb_define_singleton_method(cgsl_odeiv_control, "standard_alloc", rb_gsl_odeiv_control_standard_new, 4);
   rb_define_singleton_method(cgsl_odeiv_control, "y_new", rb_gsl_odeiv_control_y_new, 2);
   rb_define_singleton_method(cgsl_odeiv_control, "yp_new", rb_gsl_odeiv_control_yp_new, 2);
-  rb_define_singleton_method(cgsl_odeiv_control, "scaled_alloc", rb_gsl_odeiv_control_scaled_new, 5);
+  rb_define_singleton_method(cgsl_odeiv_control, "scaled_alloc", rb_gsl_odeiv_control_scaled_new, 6);
 
   rb_define_method(cgsl_odeiv_control, "init", rb_gsl_odeiv_control_init, 4);
   rb_define_method(cgsl_odeiv_control, "name", rb_gsl_odeiv_control_name, 0);

--- a/ext/gsl_native/poly_source.h
+++ b/ext/gsl_native/poly_source.h
@@ -1811,9 +1811,9 @@ void FUNCTION(Init_gsl_poly,init)(VALUE module)
                              FUNCTION(rb_gsl_poly,deconv2), 2);
 
   rb_define_method(GSL_TYPE(cgsl_poly), "reduce",
-                   FUNCTION(rb_gsl_poly,reduce), 1);
-  rb_define_method(GSL_TYPE(cgsl_poly), "deriv", FUNCTION(rb_gsl_poly,deriv), 1);
-  rb_define_method(GSL_TYPE(cgsl_poly), "integ", FUNCTION(rb_gsl_poly,integ), 1);
+                   FUNCTION(rb_gsl_poly,reduce), 0);
+  rb_define_method(GSL_TYPE(cgsl_poly), "deriv", FUNCTION(rb_gsl_poly,deriv), 0);
+  rb_define_method(GSL_TYPE(cgsl_poly), "integ", FUNCTION(rb_gsl_poly,integ), 0);
 
 /*****/
 

--- a/ext/gsl_native/rng.c
+++ b/ext/gsl_native/rng.c
@@ -465,21 +465,21 @@ static VALUE rb_gsl_rng_name(VALUE obj)
   return rb_str_new2(gsl_rng_name(r));
 }
 
-static VALUE rb_gsl_rng_max(VALUE obj, VALUE s)
+static VALUE rb_gsl_rng_max(VALUE obj)
 {
   gsl_rng *r = NULL;
   Data_Get_Struct(obj, gsl_rng, r);
   return UINT2NUM(gsl_rng_max(r));
 }
 
-static VALUE rb_gsl_rng_min(VALUE obj, VALUE s)
+static VALUE rb_gsl_rng_min(VALUE obj)
 {
   gsl_rng *r = NULL;
   Data_Get_Struct(obj, gsl_rng, r);
   return UINT2NUM(gsl_rng_min(r));
 }
 
-static VALUE rb_gsl_rng_size(VALUE obj, VALUE s)
+static VALUE rb_gsl_rng_size(VALUE obj)
 {
   gsl_rng *r = NULL;
   Data_Get_Struct(obj, gsl_rng, r);

--- a/ext/gsl_native/sf_bessel.c
+++ b/ext/gsl_native/sf_bessel.c
@@ -847,7 +847,7 @@ void Init_gsl_sf_bessel(VALUE module)
   rb_define_module_function(mgsl_sf_bessel, "kl_scaled_array",  rb_gsl_sf_bessel_kl_scaled_array, 2);
   rb_define_module_function(mgsl_sf_bessel, "Jnu",  rb_gsl_sf_bessel_Jnu, 2);
   rb_define_module_function(mgsl_sf_bessel, "Jnu_e",  rb_gsl_sf_bessel_Jnu_e, 2);
-  rb_define_module_function(mgsl_sf_bessel, "sequence_Jnu_e",  rb_gsl_sf_bessel_sequence_Jnu_e, 3);
+  rb_define_module_function(mgsl_sf_bessel, "sequence_Jnu_e",  rb_gsl_sf_bessel_sequence_Jnu_e, -1);
 
   rb_define_module_function(mgsl_sf_bessel, "Ynu",  rb_gsl_sf_bessel_Ynu, 2);
   rb_define_module_function(mgsl_sf_bessel, "Ynu_e",  rb_gsl_sf_bessel_Ynu_e, 2);

--- a/ext/gsl_native/sf_ellint.c
+++ b/ext/gsl_native/sf_ellint.c
@@ -172,7 +172,7 @@ void Init_gsl_sf_ellint(VALUE module)
   rb_define_module_function(module, "ellint_P",  rb_gsl_sf_ellint_P, -1);
   rb_define_module_function(module, "ellint_P_e",  rb_gsl_sf_ellint_P_e, 4);
   rb_define_module_function(module, "ellint_D",  rb_gsl_sf_ellint_D, -1);
-  rb_define_module_function(module, "ellint_D_e",  rb_gsl_sf_ellint_D_e, 4);
+  rb_define_module_function(module, "ellint_D_e",  rb_gsl_sf_ellint_D_e, 3);
   rb_define_module_function(module, "ellint_RC",  rb_gsl_sf_ellint_RC, -1);
   rb_define_module_function(module, "ellint_RC_e",  rb_gsl_sf_ellint_RC_e, 3);
   rb_define_module_function(module, "ellint_RD",  rb_gsl_sf_ellint_RD, -1);
@@ -194,7 +194,7 @@ void Init_gsl_sf_ellint(VALUE module)
   rb_define_module_function(mgsl_sf_ellint, "P",  rb_gsl_sf_ellint_P, -1);
   rb_define_module_function(mgsl_sf_ellint, "P_e",  rb_gsl_sf_ellint_P_e, 4);
   rb_define_module_function(mgsl_sf_ellint, "D",  rb_gsl_sf_ellint_D, -1);
-  rb_define_module_function(mgsl_sf_ellint, "D_e",  rb_gsl_sf_ellint_D_e, 4);
+  rb_define_module_function(mgsl_sf_ellint, "D_e",  rb_gsl_sf_ellint_D_e, 3);
   rb_define_module_function(mgsl_sf_ellint, "RC",  rb_gsl_sf_ellint_RC, -1);
   rb_define_module_function(mgsl_sf_ellint, "RC_e",  rb_gsl_sf_ellint_RC_e, 3);
   rb_define_module_function(mgsl_sf_ellint, "RD",  rb_gsl_sf_ellint_RD, -1);

--- a/ext/gsl_native/sf_mathieu.c
+++ b/ext/gsl_native/sf_mathieu.c
@@ -147,7 +147,7 @@ static VALUE rb_gsl_sf_mathieu_a(VALUE module, VALUE order, VALUE qq)
   return sf_mathieu_eval(order, qq, gsl_sf_mathieu_a);
 #endif
 }
-static VALUE rb_gsl_sf_mathieu_a_array(VALUE module, int argc, VALUE *argv)
+static VALUE rb_gsl_sf_mathieu_a_array(int argc, VALUE *argv, VALUE module)
 {
   return sf_mathieu_array_eval(argc, argv, gsl_sf_mathieu_a_array);
 }
@@ -167,7 +167,7 @@ static VALUE rb_gsl_sf_mathieu_b(VALUE module, VALUE order, VALUE qq)
   return sf_mathieu_eval(order, qq, gsl_sf_mathieu_b);
 #endif
 }
-static VALUE rb_gsl_sf_mathieu_b_array(VALUE module, int argc, VALUE *argv)
+static VALUE rb_gsl_sf_mathieu_b_array(int argc, VALUE *argv, VALUE module)
 {
   return sf_mathieu_array_eval(argc, argv, gsl_sf_mathieu_b_array);
 }
@@ -187,7 +187,7 @@ static VALUE rb_gsl_sf_mathieu_ce(VALUE module, VALUE order, VALUE qq, VALUE zz)
   return sf_mathieu_eval_int_double2(order, qq, zz, gsl_sf_mathieu_ce);
 #endif
 }
-static VALUE rb_gsl_sf_mathieu_ce_array(VALUE module, int argc, VALUE *argv)
+static VALUE rb_gsl_sf_mathieu_ce_array(int argc, VALUE *argv, VALUE module)
 {
   return sf_mathieu_array_eval2(argc, argv, gsl_sf_mathieu_ce_array);
 }
@@ -207,7 +207,7 @@ static VALUE rb_gsl_sf_mathieu_se(VALUE module, VALUE order, VALUE qq, VALUE zz)
   return sf_mathieu_eval_int_double2(order, qq, zz, gsl_sf_mathieu_se);
 #endif
 }
-static VALUE rb_gsl_sf_mathieu_se_array(VALUE module, int argc, VALUE *argv)
+static VALUE rb_gsl_sf_mathieu_se_array(int argc, VALUE *argv, VALUE module)
 {
   return sf_mathieu_array_eval2(argc, argv, gsl_sf_mathieu_se_array);
 }
@@ -229,7 +229,7 @@ static VALUE rb_gsl_sf_mathieu_Mc(VALUE module, VALUE n1, VALUE n2, VALUE q, VAL
   return sf_mathieu_eval2(n1, n2, q, x, gsl_sf_mathieu_Mc);
 #endif
 }
-static VALUE rb_gsl_sf_mathieu_Mc_array(VALUE module, int argc, VALUE *argv)
+static VALUE rb_gsl_sf_mathieu_Mc_array(int argc, VALUE *argv, VALUE module)
 {
   return sf_mathieu_array_eval3(argc, argv, gsl_sf_mathieu_Mc_array);
 }
@@ -249,7 +249,7 @@ static VALUE rb_gsl_sf_mathieu_Ms(VALUE module, VALUE n1, VALUE n2, VALUE q, VAL
   return sf_mathieu_eval2(n1, n2, q, x, gsl_sf_mathieu_Ms);
 #endif
 }
-static VALUE rb_gsl_sf_mathieu_Ms_array(VALUE module, int argc, VALUE *argv)
+static VALUE rb_gsl_sf_mathieu_Ms_array(int argc, VALUE *argv, VALUE module)
 {
   return sf_mathieu_array_eval3(argc, argv, gsl_sf_mathieu_Ms_array);
 }

--- a/ext/gsl_native/spline.c
+++ b/ext/gsl_native/spline.c
@@ -398,7 +398,7 @@ void Init_gsl_spline(VALUE module)
   rb_define_alias(cgsl_spline, "deriv_e", "eval_deriv_e");
   rb_define_method(cgsl_spline, "eval_deriv2_e", rb_gsl_spline_eval_deriv2_e, 1);
   rb_define_alias(cgsl_spline, "deri2v_e", "eval_deriv2_e");
-  rb_define_method(cgsl_spline, "eval_integ_e", rb_gsl_spline_eval_integ_e, 1);
+  rb_define_method(cgsl_spline, "eval_integ_e", rb_gsl_spline_eval_integ_e, 2);
   rb_define_alias(cgsl_spline, "integ_e", "eval_integ_e");
 
   rb_define_method(cgsl_spline, "info", rb_gsl_spline_info, 0);

--- a/ext/gsl_native/stats.c
+++ b/ext/gsl_native/stats.c
@@ -706,20 +706,20 @@ void Init_gsl_stats(VALUE module)
 
   /*****/
 
-  rb_define_singleton_method(mgsl_stats, "wmean", rb_gsl_stats_wmean2, -1);
-  rb_define_singleton_method(mgsl_stats, "wvariance", rb_gsl_stats_wvariance2, -1);
-  rb_define_singleton_method(mgsl_stats, "wvariance_m", rb_gsl_stats_wvariance_m2, -1);
-  rb_define_singleton_method(mgsl_stats, "wsd", rb_gsl_stats_wsd2, -1);
-  rb_define_singleton_method(mgsl_stats, "wsd_m", rb_gsl_stats_wsd_m2, -1);
+  rb_define_singleton_method(mgsl_stats, "wmean", rb_gsl_stats_wmean2, 2);
+  rb_define_singleton_method(mgsl_stats, "wvariance", rb_gsl_stats_wvariance2, 2);
+  rb_define_singleton_method(mgsl_stats, "wvariance_m", rb_gsl_stats_wvariance_m2, 3);
+  rb_define_singleton_method(mgsl_stats, "wsd", rb_gsl_stats_wsd2, 2);
+  rb_define_singleton_method(mgsl_stats, "wsd_m", rb_gsl_stats_wsd_m2, 3);
   rb_define_singleton_method(mgsl_stats, "wvariance_with_fixed_mean",
-                             rb_gsl_stats_wvariance_with_fixed_mean2, -1);
+                             rb_gsl_stats_wvariance_with_fixed_mean2, 3);
   rb_define_singleton_method(mgsl_stats, "wsd_with_fixed_mean",
-                             rb_gsl_stats_wsd_with_fixed_mean2, -1);
-  rb_define_singleton_method(mgsl_stats, "wabsdev", rb_gsl_stats_wabsdev2, -1);
-  rb_define_singleton_method(mgsl_stats, "wabsdev_m", rb_gsl_stats_wabsdev_m2, -1);
-  rb_define_singleton_method(mgsl_stats, "wskew", rb_gsl_stats_wskew2, -1);
+                             rb_gsl_stats_wsd_with_fixed_mean2, 3);
+  rb_define_singleton_method(mgsl_stats, "wabsdev", rb_gsl_stats_wabsdev2, 2);
+  rb_define_singleton_method(mgsl_stats, "wabsdev_m", rb_gsl_stats_wabsdev_m2, 3);
+  rb_define_singleton_method(mgsl_stats, "wskew", rb_gsl_stats_wskew2, 2);
   rb_define_singleton_method(mgsl_stats, "wskew_m_sd", rb_gsl_stats_wskew_m2, 4);
-  rb_define_singleton_method(mgsl_stats, "wkurtosis", rb_gsl_stats_wkurtosis2, -1);
+  rb_define_singleton_method(mgsl_stats, "wkurtosis", rb_gsl_stats_wkurtosis2, 2);
   rb_define_singleton_method(mgsl_stats, "wkurtosis_m_sd", rb_gsl_stats_wkurtosis_m2, 4);
 
   /*****/
@@ -747,12 +747,12 @@ void Init_gsl_stats(VALUE module)
   rb_define_alias(cgsl_vector, "wabsdev_m", "stats_wabsdev_m");
   rb_define_method(cgsl_vector, "stats_wskew", rb_gsl_stats_wskew, -1);
   rb_define_alias(cgsl_vector, "wskew", "stats_wskew");
-  rb_define_method(cgsl_vector, "stats_wskew_m_sd", rb_gsl_stats_wskew_m_sd, 2);
+  rb_define_method(cgsl_vector, "stats_wskew_m_sd", rb_gsl_stats_wskew_m_sd, 3);
   rb_define_alias(cgsl_vector, "wskew_m_sd", "stats_wskew_m_sd");
   rb_define_method(cgsl_vector, "stats_wkurtosis", rb_gsl_stats_wkurtosis, -1);
   rb_define_alias(cgsl_vector, "wkurtosis", "stats_wkurtosis");
   rb_define_method(cgsl_vector, "stats_wkurtosis_m_sd",
-                   rb_gsl_stats_wkurtosis_m_sd, 2);
+                   rb_gsl_stats_wkurtosis_m_sd, 3);
   rb_define_alias(cgsl_vector, "wkurtosis_m_sd", "stats_wkurtosis_m_sd");
 
   /*****/

--- a/ext/gsl_native/vector_complex.c
+++ b/ext/gsl_native/vector_complex.c
@@ -1829,7 +1829,7 @@ static VALUE rb_gsl_vector_complex_block(VALUE obj)
   return Data_Wrap_Struct(cgsl_block_complex, 0, NULL, v->block);
 }
 
-static VALUE rb_gsl_vector_complex_indgen_bang(int argc, VALUE *argv[], VALUE obj)
+static VALUE rb_gsl_vector_complex_indgen_bang(int argc, VALUE *argv, VALUE obj)
 {
   gsl_vector_complex *v = NULL;
   double start = 0.0, step = 1.0, x;
@@ -2112,7 +2112,7 @@ void Init_gsl_vector_complex(VALUE module)
   rb_define_method(cgsl_vector_complex, "isnull", rb_gsl_vector_complex_isnull, 0);
 
   rb_define_method(cgsl_vector_complex, "matrix_view", rb_gsl_vector_complex_matrix_view, -1);
-  rb_define_method(cgsl_vector_complex, "matrix_view_with_tda", rb_gsl_vector_complex_matrix_view_with_tda, -1);
+  rb_define_method(cgsl_vector_complex, "matrix_view_with_tda", rb_gsl_vector_complex_matrix_view_with_tda, 3);
 
   rb_define_method(cgsl_vector_complex, "trans", rb_gsl_vector_complex_trans, 0);
   rb_define_alias(cgsl_vector_complex, "transpose", "trans");


### PR DESCRIPTION
## Summary

Fixes compilation errors on Ruby 3.4 caused by stricter function pointer type checking.

- Fix argc values to match function signatures
- Fix parameter order for variadic functions
- Fix double pointer typos (`VALUE *argv[]` → `VALUE *argv`)
- Remove unused parameters from rng max/min/size
- Update rb_rescue callback signature (2 args required)
- Use GSL 2.8 API (`gsl_bspline_ncontrol`)
- Remove duplicate `gsl_matrix_complex_conjugate` (now in GSL 2.8+)

## Test Plan

- [x] Compiles on Ruby 3.4.8 + GSL 2.8 + macOS arm64
- [x] Full test suite passes: **755 tests, 1,514,054 assertions, 0 failures, 0 errors**

Fixes #75